### PR TITLE
nack messages that can't be decoded

### DIFF
--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/algebra/Consuming.scala
@@ -18,7 +18,7 @@ package com.github.gvolpe.fs2rabbit.algebra
 
 import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.effects.EnvelopeDecoder
-import com.github.gvolpe.fs2rabbit.model.{AmqpEnvelope, BasicQos, ConsumerTag, QueueName}
+import com.github.gvolpe.fs2rabbit.model._
 import com.rabbitmq.client.Channel
 
 trait Consuming[F[_], G[_]] {
@@ -27,11 +27,11 @@ trait Consuming[F[_], G[_]] {
       queueName: QueueName,
       channel: Channel,
       basicQos: BasicQos,
-      autoAck: Boolean = false,
       noLocal: Boolean = false,
       exclusive: Boolean = false,
       consumerTag: ConsumerTag = ConsumerTag(""),
-      args: Arguments = Map.empty
+      args: Arguments = Map.empty,
+      acker: Option[AckResult => G[Unit]]
   )(implicit decoder: EnvelopeDecoder[G, A]): F[AmqpEnvelope[A]]
 
 }

--- a/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/ConsumingProgram.scala
+++ b/core/src/main/scala/com/github/gvolpe/fs2rabbit/program/ConsumingProgram.scala
@@ -17,15 +17,19 @@
 package com.github.gvolpe.fs2rabbit.program
 
 import cats.MonadError
+import cats.syntax.applicativeError._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.monadError._
 import com.github.gvolpe.fs2rabbit.algebra.{AMQPClient, AMQPInternals, Consuming, InternalQueue}
 import com.github.gvolpe.fs2rabbit.arguments.Arguments
 import com.github.gvolpe.fs2rabbit.effects.EnvelopeDecoder
+import com.github.gvolpe.fs2rabbit.model.AckResult.NAck
 import com.github.gvolpe.fs2rabbit.model._
 import com.rabbitmq.client.Channel
 import fs2.Stream
+
+import scala.util.control.NonFatal
 
 class ConsumingProgram[F[_]: MonadError[?[_], Throwable]](AMQP: AMQPClient[Stream[F, ?], F], IQ: InternalQueue[F])
     extends Consuming[Stream[F, ?], F] {
@@ -34,19 +38,29 @@ class ConsumingProgram[F[_]: MonadError[?[_], Throwable]](AMQP: AMQPClient[Strea
       queueName: QueueName,
       channel: Channel,
       basicQos: BasicQos,
-      autoAck: Boolean = false,
       noLocal: Boolean = false,
       exclusive: Boolean = false,
       consumerTag: ConsumerTag = ConsumerTag(""),
-      args: Arguments = Map.empty
+      args: Arguments = Map.empty,
+      acker: Option[AckResult => F[Unit]]
   )(implicit decoder: EnvelopeDecoder[F, A]): Stream[F, AmqpEnvelope[A]] =
     for {
       internalQ <- Stream.eval(IQ.create)
       internals = AMQPInternals[F](Some(internalQ))
       _         <- AMQP.basicQos(channel, basicQos)
-      consumeF  = AMQP.basicConsume(channel, queueName, autoAck, consumerTag, noLocal, exclusive, args)(internals)
+      consumeF  = AMQP.basicConsume(channel, queueName, acker.isEmpty, consumerTag, noLocal, exclusive, args)(internals)
       _         <- Stream.bracket(consumeF)(tag => AMQP.basicCancel(channel, tag))
-      consumer <- Stream.repeatEval(
-                   internalQ.dequeue1.rethrow.flatMap(env => decoder(env).map(a => env.copy(payload = a))))
+      consumer <- Stream.repeatEval {
+                   internalQ.dequeue1.rethrow.flatMap { env =>
+                     val decoded = acker match {
+                       case Some(acker) =>
+                         decoder(env).onError {
+                           case NonFatal(_) => acker(NAck(env.deliveryTag))
+                         }
+                       case None => decoder(env)
+                     }
+                     decoded.map(a => env.copy(payload = a))
+                   }
+                 }
     } yield consumer
 }


### PR DESCRIPTION
Hi,

it's currently quite hard to NAck messages when the envelope decoder fails to decode them. But I think that's basically always what you want, so I propose to do it in the library. People who don't want that can always use an `EnvelopeDecoder[F, Either[Throwable, A]]` and do all the error handling manually.

I haven't bothered fixing the tests, docs or examples, I'll do that later if we can agree on this behaviour.

Cheers,
Matthias