### PR TITLE
Move Blocker dependency in publisher creation

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AMQPClient.scala
@@ -31,10 +31,8 @@ trait AMQPClient[F[_]] extends Binding[F] with Declaration[F] with Deletion[F] {
   def basicConsume[A](channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: ConsumerTag, noLocal: Boolean, exclusive: Boolean, args: Arguments)
                   (internals: AMQPInternals[F]): F[ConsumerTag]
   def basicCancel(channel: Channel, consumerTag: ConsumerTag): F[Unit]
-  def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[Array[Byte]])
-                  (blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit]
-  def basicPublishWithFlag(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, flag: PublishingFlag, msg: AmqpMessage[Array[Byte]])
-                          (blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit]
+  def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[Array[Byte]], blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit]
+  def basicPublishWithFlag(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, flag: PublishingFlag, msg: AmqpMessage[Array[Byte]], blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit]
   def addPublishingListener(channel: Channel, listener: PublishReturn => F[Unit]): F[Unit]
   def clearPublishingListeners(channel: Channel): F[Unit]
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AMQPClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AMQPClient.scala
@@ -16,6 +16,7 @@
 
 package dev.profunktor.fs2rabbit.algebra
 
+import cats.effect.{Blocker, ContextShift}
 import dev.profunktor.fs2rabbit.arguments.Arguments
 import dev.profunktor.fs2rabbit.config.declaration.{DeclarationExchangeConfig, DeclarationQueueConfig}
 import dev.profunktor.fs2rabbit.config.deletion.{DeletionExchangeConfig, DeletionQueueConfig}
@@ -30,8 +31,10 @@ trait AMQPClient[F[_]] extends Binding[F] with Declaration[F] with Deletion[F] {
   def basicConsume[A](channel: Channel, queueName: QueueName, autoAck: Boolean, consumerTag: ConsumerTag, noLocal: Boolean, exclusive: Boolean, args: Arguments)
                   (internals: AMQPInternals[F]): F[ConsumerTag]
   def basicCancel(channel: Channel, consumerTag: ConsumerTag): F[Unit]
-  def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[Array[Byte]]): F[Unit]
-  def basicPublishWithFlag(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, flag: PublishingFlag, msg: AmqpMessage[Array[Byte]]): F[Unit]
+  def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[Array[Byte]])
+                  (blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit]
+  def basicPublishWithFlag(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, flag: PublishingFlag, msg: AmqpMessage[Array[Byte]])
+                          (blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit]
   def addPublishingListener(channel: Channel, listener: PublishReturn => F[Unit]): F[Unit]
   def clearPublishingListeners(channel: Channel): F[Unit]
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Publishing.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Publishing.scala
@@ -16,6 +16,7 @@
 
 package dev.profunktor.fs2rabbit.algebra
 
+import cats.effect.{Blocker, ContextShift}
 import com.rabbitmq.client.Channel
 import dev.profunktor.fs2rabbit.effects.MessageEncoder
 import dev.profunktor.fs2rabbit.model._
@@ -25,37 +26,43 @@ trait Publishing[F[_]] {
   def createPublisher[A](
       channel: Channel,
       exchangeName: ExchangeName,
-      routingKey: RoutingKey
-  )(implicit encoder: MessageEncoder[F, A]): F[A => F[Unit]]
+      routingKey: RoutingKey,
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[A => F[Unit]]
 
   def createPublisherWithListener[A](
       channel: Channel,
       exchangeName: ExchangeName,
       routingKey: RoutingKey,
       flags: PublishingFlag,
-      listener: PublishReturn => F[Unit]
-  )(implicit encoder: MessageEncoder[F, A]): F[A => F[Unit]]
+      listener: PublishReturn => F[Unit],
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[A => F[Unit]]
 
   def createRoutingPublisher[A](
       channel: Channel,
-      exchangeName: ExchangeName
-  )(implicit encoder: MessageEncoder[F, A]): F[RoutingKey => A => F[Unit]]
+      exchangeName: ExchangeName,
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[RoutingKey => A => F[Unit]]
 
   def createRoutingPublisherWithListener[A](
       channel: Channel,
       exchangeName: ExchangeName,
       flags: PublishingFlag,
-      listener: PublishReturn => F[Unit]
-  )(implicit encoder: MessageEncoder[F, A]): F[RoutingKey => A => F[Unit]]
+      listener: PublishReturn => F[Unit],
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[RoutingKey => A => F[Unit]]
 
   def createBasicPublisher[A](
-      channel: Channel
-  )(implicit encoder: MessageEncoder[F, A]): F[(ExchangeName, RoutingKey, A) => F[Unit]]
+      channel: Channel,
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[(ExchangeName, RoutingKey, A) => F[Unit]]
 
   def createBasicPublisherWithListener[A](
       channel: Channel,
       flags: PublishingFlag,
-      listener: PublishReturn => F[Unit]
-  )(implicit encoder: MessageEncoder[F, A]): F[(ExchangeName, RoutingKey, A) => F[Unit]]
+      listener: PublishReturn => F[Unit],
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[(ExchangeName, RoutingKey, A) => F[Unit]]
 
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/AMQPClientEffect.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/AMQPClientEffect.scala
@@ -147,8 +147,11 @@ class AMQPClientEffect[F[_]: Effect] extends AMQPClient[F] {
       channel.basicCancel(consumerTag.value)
     }
 
-  def basicPublish(channel: Channel, exchangeName: ExchangeName, routingKey: RoutingKey, msg: AmqpMessage[Array[Byte]])(
-      blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit] = blocker.delay {
+  def basicPublish(channel: Channel,
+                   exchangeName: ExchangeName,
+                   routingKey: RoutingKey,
+                   msg: AmqpMessage[Array[Byte]],
+                   blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit] = blocker.delay {
     channel.basicPublish(
       exchangeName.value,
       routingKey.value,
@@ -161,7 +164,8 @@ class AMQPClientEffect[F[_]: Effect] extends AMQPClient[F] {
                            exchangeName: ExchangeName,
                            routingKey: RoutingKey,
                            flag: PublishingFlag,
-                           msg: AmqpMessage[Array[Byte]])(blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit] =
+                           msg: AmqpMessage[Array[Byte]],
+                           blocker: Blocker)(implicit cs: ContextShift[F]): F[Unit] =
     blocker.delay {
       channel.basicPublish(
         exchangeName.value,

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgram.scala
@@ -16,6 +16,7 @@
 
 package dev.profunktor.fs2rabbit.program
 
+import cats.effect.{Blocker, ContextShift}
 import cats.{Applicative, Monad}
 import cats.implicits._
 import dev.profunktor.fs2rabbit.algebra.{AMQPClient, Publishing}
@@ -28,50 +29,58 @@ class PublishingProgram[F[_]: Monad](AMQP: AMQPClient[F]) extends Publishing[F] 
   override def createPublisher[A](
       channel: Channel,
       exchangeName: ExchangeName,
-      routingKey: RoutingKey
-  )(implicit encoder: MessageEncoder[F, A]): F[A => F[Unit]] =
-    createRoutingPublisher(channel, exchangeName).map(_.apply(routingKey))
+      routingKey: RoutingKey,
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[A => F[Unit]] =
+    createRoutingPublisher(channel, exchangeName, blocker).map(_.apply(routingKey))
 
   override def createPublisherWithListener[A](
       channel: Channel,
       exchangeName: ExchangeName,
       routingKey: RoutingKey,
       flag: PublishingFlag,
-      listener: PublishReturn => F[Unit]
-  )(implicit encoder: MessageEncoder[F, A]): F[A => F[Unit]] =
-    createRoutingPublisherWithListener(channel, exchangeName, flag, listener).map(_.apply(routingKey))
+      listener: PublishReturn => F[Unit],
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[A => F[Unit]] =
+    createRoutingPublisherWithListener(channel, exchangeName, flag, listener, blocker).map(_.apply(routingKey))
 
   override def createRoutingPublisher[A](
       channel: Channel,
-      exchangeName: ExchangeName
-  )(implicit encoder: MessageEncoder[F, A]): F[RoutingKey => A => F[Unit]] =
-    createBasicPublisher(channel).map(pub => key => msg => pub(exchangeName, key, msg))
+      exchangeName: ExchangeName,
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[RoutingKey => A => F[Unit]] =
+    createBasicPublisher(channel, blocker).map(pub => key => msg => pub(exchangeName, key, msg))
 
   override def createRoutingPublisherWithListener[A](
       channel: Channel,
       exchangeName: ExchangeName,
       flag: PublishingFlag,
-      listener: PublishReturn => F[Unit]
-  )(implicit encoder: MessageEncoder[F, A]): F[RoutingKey => A => F[Unit]] =
-    createBasicPublisherWithListener(channel, flag, listener).map(
+      listener: PublishReturn => F[Unit],
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[RoutingKey => A => F[Unit]] =
+    createBasicPublisherWithListener(channel, flag, listener, blocker).map(
       pub => key => msg => pub(exchangeName, key, msg)
     )
 
   override def createBasicPublisher[A](
-      channel: Channel
-  )(implicit encoder: MessageEncoder[F, A]): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
+      channel: Channel,
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
     Applicative[F].pure {
       case (exchangeName: ExchangeName, routingKey: RoutingKey, msg: A @unchecked) =>
-        encoder.run(msg).flatMap(payload => AMQP.basicPublish(channel, exchangeName, routingKey, payload))
+        encoder.run(msg).flatMap(payload => AMQP.basicPublish(channel, exchangeName, routingKey, payload)(blocker))
     }
 
   override def createBasicPublisherWithListener[A](
       channel: Channel,
       flag: PublishingFlag,
-      listener: PublishReturn => F[Unit]
-  )(implicit encoder: MessageEncoder[F, A]): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
+      listener: PublishReturn => F[Unit],
+      blocker: Blocker
+  )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
     AMQP.addPublishingListener(channel, listener).as {
       case (exchangeName: ExchangeName, routingKey: RoutingKey, msg: A @unchecked) =>
-        encoder.run(msg).flatMap(payload => AMQP.basicPublishWithFlag(channel, exchangeName, routingKey, flag, payload))
+        encoder
+          .run(msg)
+          .flatMap(payload => AMQP.basicPublishWithFlag(channel, exchangeName, routingKey, flag, payload)(blocker))
     }
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgram.scala
@@ -68,7 +68,7 @@ class PublishingProgram[F[_]: Monad](AMQP: AMQPClient[F]) extends Publishing[F] 
   )(implicit encoder: MessageEncoder[F, A], cs: ContextShift[F]): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
     Applicative[F].pure {
       case (exchangeName: ExchangeName, routingKey: RoutingKey, msg: A @unchecked) =>
-        encoder.run(msg).flatMap(payload => AMQP.basicPublish(channel, exchangeName, routingKey, payload)(blocker))
+        encoder.run(msg).flatMap(payload => AMQP.basicPublish(channel, exchangeName, routingKey, payload, blocker))
     }
 
   override def createBasicPublisherWithListener[A](
@@ -81,6 +81,6 @@ class PublishingProgram[F[_]: Monad](AMQP: AMQPClient[F]) extends Publishing[F] 
       case (exchangeName: ExchangeName, routingKey: RoutingKey, msg: A @unchecked) =>
         encoder
           .run(msg)
-          .flatMap(payload => AMQP.basicPublishWithFlag(channel, exchangeName, routingKey, flag, payload)(blocker))
+          .flatMap(payload => AMQP.basicPublishWithFlag(channel, exchangeName, routingKey, flag, payload, blocker))
     }
 }

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/AckerConsumerDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/AckerConsumerDemo.scala
@@ -29,7 +29,7 @@ import dev.profunktor.fs2rabbit.model.AmqpFieldValue.{LongVal, StringVal}
 import dev.profunktor.fs2rabbit.model._
 import fs2._
 
-class AckerConsumerDemo[F[_]: Concurrent: Timer](R: Fs2Rabbit[F]) {
+class AckerConsumerDemo[F[_]: Concurrent: Timer: ContextShift](R: Fs2Rabbit[F], blocker: Blocker) {
   private val queueName    = QueueName("testQ")
   private val exchangeName = ExchangeName("testEX")
   private val routingKey   = RoutingKey("testRK")
@@ -56,7 +56,8 @@ class AckerConsumerDemo[F[_]: Concurrent: Timer](R: Fs2Rabbit[F]) {
                     exchangeName,
                     routingKey,
                     publishingFlag,
-                    publishingListener
+                    publishingListener,
+                    blocker
                   )
       _ <- new Flow[F, String](consumer, acker, logPipe, publisher).flow.compile.drain
     } yield ()

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
@@ -50,9 +50,9 @@ object IOAckerConsumer extends IOApp {
 
   override def run(args: List[String]): IO[ExitCode] =
     blockerResource.use { blocker =>
-      Fs2Rabbit[IO](config, blocker).flatMap { client =>
+      Fs2Rabbit[IO](config).flatMap { client =>
         ResilientStream
-          .runF(new AckerConsumerDemo[IO](client).program)
+          .runF(new AckerConsumerDemo[IO](client, blocker).program)
           .as(ExitCode.Success)
       }
     }

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -51,9 +51,9 @@ object MonixAutoAckConsumer extends TaskApp {
 
   override def run(args: List[String]): Task[ExitCode] =
     blockerResource.use { blocker =>
-      Fs2Rabbit[Task](config, blocker).flatMap { client =>
+      Fs2Rabbit[Task](config).flatMap { client =>
         ResilientStream
-          .runF(new AutoAckConsumerDemo[Task](client).program)
+          .runF(new AutoAckConsumerDemo[Task](client, blocker).program)
           .as(ExitCode.Success)
       }
     }

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/ZIOAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/ZIOAutoAckConsumer.scala
@@ -48,9 +48,9 @@ object ZIOAutoAckConsumer extends CatsApp {
   override def run(args: List[String]): UIO[Int] =
     blockerResource
       .use { blocker =>
-        Fs2Rabbit[Task](config, blocker).flatMap { client =>
+        Fs2Rabbit[Task](config).flatMap { client =>
           ResilientStream
-            .runF(new AutoAckConsumerDemo[Task](client).program)
+            .runF(new AutoAckConsumerDemo[Task](client, blocker).program)
         }
       }
       .run

--- a/site/src/main/tut/client.md
+++ b/site/src/main/tut/client.md
@@ -6,7 +6,7 @@ number: 2
 
 # Fs2 Rabbit Client
 
-`Fs2Rabbit` is the main client that wraps the communication  with `RabbitMQ`. The mandatory arguments are a `Fs2RabbitConfig` and a `cats.effect.Blocker` used for publishing (this action is blocking in the underlying Java client). Optionally, you can pass in a custom `SSLContext` and `SaslConfig`.
+`Fs2Rabbit` is the main client that wraps the communication  with `RabbitMQ`. The mandatory arguments is a `Fs2RabbitConfig`. Optionally, you can pass in a custom `SSLContext` and `SaslConfig`.
 
 ```tut:book:silent
 import cats.effect._
@@ -18,7 +18,6 @@ import javax.net.ssl.SSLContext
 object Fs2Rabbit {
   def apply[F[_]: ConcurrentEffect: ContextShift](
     config: Fs2RabbitConfig,
-    blocker: Blocker,
     sslContext: Option[SSLContext] = None,
     saslConfig: SaslConfig = DefaultSaslConfig.PLAIN
   ): F[Fs2Rabbit[F]] = ???
@@ -52,17 +51,9 @@ class Demo extends IOApp {
     internalQueueSize = Some(500)
   )
 
-  val blockerResource =
-    Resource
-      .make(IO(Executors.newCachedThreadPool()))(es => IO(es.shutdown()))
-      .map(Blocker.liftExecutorService)
-
   override def run(args: List[String]): IO[ExitCode] =
-    blockerResource.use { blocker =>
-      Fs2Rabbit[IO](config, blocker).flatMap { client =>
+      Fs2Rabbit[IO](config).flatMap { client =>
         Program.foo[IO](client).as(ExitCode.Success)
       }
-    }
-
 }
 ```

--- a/site/src/main/tut/examples/sample-mult-consumers.md
+++ b/site/src/main/tut/examples/sample-mult-consumers.md
@@ -35,7 +35,7 @@ def multipleConsumers(c1: Stream[IO, AmqpEnvelope[String]], c2: Stream[IO, AmqpE
   ).parJoin(3)
 }
 
-def program(R: Fs2Rabbit[IO]) =
+def program(R: Fs2Rabbit[IO], blocker: Blocker) =
   R.createConnectionChannel.use { implicit channel =>
     for {
       _  <- R.declareExchange(ex, ExchangeType.Topic)
@@ -45,7 +45,7 @@ def program(R: Fs2Rabbit[IO]) =
       _  <- R.bindQueue(q2, ex, rkb)
       c1 <- R.createAutoAckConsumer[String](q1)
       c2 <- R.createAutoAckConsumer[String](q2)
-      p  <- R.createPublisher[String](ex, rka)
+      p  <- R.createPublisher[String](ex, rka, blocker)
       _  <- multipleConsumers(c1, c2, p).compile.drain
     } yield ()
   }

--- a/site/src/main/tut/publishers/publisher-with-listener.md
+++ b/site/src/main/tut/publishers/publisher-with-listener.md
@@ -18,7 +18,7 @@ The server SHOULD implement the mandatory flag.
 
 ### Creating a Publisher with Listener
 
-It is simply created by specifying `ExchangeName`, `RoutingKey`, `PublishingFlag` and a listener, i.e. a function from `PublishReturn` to `F[Unit]`:
+It is simply created by specifying `ExchangeName`, `RoutingKey`, `PublishingFlag`, a listener (i.e. a function from `PublishReturn` to `F[Unit]`) and a `cats.effect.Blocker`, which is used for publishing (this action is blocking in the underlying Java client):
 
 ```tut:book:silent
 import cats.effect._
@@ -34,9 +34,9 @@ val publishingListener: PublishReturn => IO[Unit] = pr => IO(println(s"Publish l
 
 def doSomething(publisher: String => IO[Unit]): IO[Unit] = IO.unit
 
-def program(R: Fs2Rabbit[IO]) =
+def program(R: Fs2Rabbit[IO], blocker: Blocker)(implicit cs: ContextShift[IO]) =
   R.createConnectionChannel.use { implicit channel =>
-    R.createPublisherWithListener[String](exchangeName, routingKey, publishingFlag, publishingListener).flatMap(doSomething)
+    R.createPublisherWithListener[String](exchangeName, routingKey, publishingFlag, publishingListener, blocker).flatMap(doSomething)
   }
 ```
 

--- a/site/src/main/tut/publishers/publisher.md
+++ b/site/src/main/tut/publishers/publisher.md
@@ -6,7 +6,7 @@ number: 11
 
 # Publisher
 
-A `Publisher` is simply created by specifying an `ExchangeName` and a `RoutingKey`:
+A `Publisher` is simply created by specifying an `ExchangeName`, `RoutingKey` and a `cats.effect.Blocker`, which is used for publishing (this action is blocking in the underlying Java client):
 
 ```tut:book:silent
 import cats.effect._
@@ -18,9 +18,9 @@ val routingKey   = RoutingKey("testRK")
 
 def doSomething(publisher: String => IO[Unit]): IO[Unit] = IO.unit
 
-def program(R: Fs2Rabbit[IO]) =
+def program(R: Fs2Rabbit[IO], blocker: Blocker)(implicit cs: ContextShift[IO]) =
   R.createConnectionChannel.use { implicit channel =>
-    R.createPublisher[String](exchangeName, routingKey).flatMap(doSomething)
+    R.createPublisher[String](exchangeName, routingKey, blocker).flatMap(doSomething)
   }
 ```
 


### PR DESCRIPTION
Right now there's a dependency for a `Blocker` at `Fs2Rabbit` creation level.
Since `Blocker` is only needed for publishing operations, I thought it may be helpful to properly move this dependency, so that flows that only consume won't need to create and pass a dependency which won't be used at all.

I know this was a deliberate design decision and I can see why this decision was taken.
I'll just leave this here :)