### PR TITLE
Adding support for timestamp property

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -305,6 +305,7 @@ object model {
       expiration: Option[String] = None,
       replyTo: Option[String] = None,
       clusterId: Option[String] = None,
+      timestamp: Option[Date] = None,
       headers: Map[String, AmqpFieldValue] = Map.empty
   )
 
@@ -335,6 +336,7 @@ object model {
         expiration = Option(basicProps.getExpiration),
         replyTo = Option(basicProps.getReplyTo),
         clusterId = Option(basicProps.getClusterId),
+        timestamp = Option(basicProps.getTimestamp),
         headers = Option(basicProps.getHeaders)
           .fold(Map.empty[String, Object])(_.asScala.toMap)
           .map {
@@ -357,6 +359,7 @@ object model {
           .expiration(props.expiration.orNull)
           .replyTo(props.replyTo.orNull)
           .clusterId(props.clusterId.orNull)
+          .timestamp(props.timestamp.orNull)
           // Note we don't use mapValues here to maintain compatibility between
           // Scala 2.12 and 2.13
           .headers(props.headers.map { case (key, value) => (key, value.toValueWriterCompatibleJava) }.asJava)

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -337,7 +337,7 @@ object model {
         expiration = Option(basicProps.getExpiration),
         replyTo = Option(basicProps.getReplyTo),
         clusterId = Option(basicProps.getClusterId),
-        timestamp = Option(basicProps.getTimestamp.toInstant),
+        timestamp = Option(basicProps.getTimestamp).map(_.toInstant),
         headers = Option(basicProps.getHeaders)
           .fold(Map.empty[String, Object])(_.asScala.toMap)
           .map {

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -256,6 +256,7 @@ object model {
       // only read a maximum of 4 bytes before bailing out (similarly it will
       // read no more than the first 8 bits to determine scale).
       case bd: java.math.BigDecimal => DecimalVal.unsafeFrom(bd)
+      case ts: java.time.Instant    => TimestampVal.from(ts)
       case d: java.util.Date        => TimestampVal.from(d)
       // Looking at com.rabbitmq.client.impl.ValueReader.readFieldValue reveals
       // that java.util.Maps must always be created by
@@ -305,7 +306,7 @@ object model {
       expiration: Option[String] = None,
       replyTo: Option[String] = None,
       clusterId: Option[String] = None,
-      timestamp: Option[Date] = None,
+      timestamp: Option[Instant] = None,
       headers: Map[String, AmqpFieldValue] = Map.empty
   )
 
@@ -336,7 +337,7 @@ object model {
         expiration = Option(basicProps.getExpiration),
         replyTo = Option(basicProps.getReplyTo),
         clusterId = Option(basicProps.getClusterId),
-        timestamp = Option(basicProps.getTimestamp),
+        timestamp = Option(basicProps.getTimestamp.toInstant),
         headers = Option(basicProps.getHeaders)
           .fold(Map.empty[String, Object])(_.asScala.toMap)
           .map {
@@ -359,7 +360,7 @@ object model {
           .expiration(props.expiration.orNull)
           .replyTo(props.replyTo.orNull)
           .clusterId(props.clusterId.orNull)
-          .timestamp(props.timestamp.orNull)
+          .timestamp(props.timestamp.map(Date.from).orNull)
           // Note we don't use mapValues here to maintain compatibility between
           // Scala 2.12 and 2.13
           .headers(props.headers.map { case (key, value) => (key, value.toValueWriterCompatibleJava) }.asJava)

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
@@ -186,7 +186,7 @@ trait AmqpPropertiesArbitraries extends PropertyChecks {
       expiration      <- Gen.option(Gen.alphaNumStr)
       replyTo         <- Gen.option(Gen.alphaNumStr)
       clusterId       <- Gen.option(Gen.alphaNumStr)
-      timestamp       <- Gen.option(dateVal.arbitrary.map(_.toValueWriterCompatibleJava))
+      timestamp       <- Gen.option(dateVal.arbitrary.map(_.instantWithOneSecondAccuracy))
       headers         <- Gen.mapOf[String, AmqpFieldValue](headersGen)
     } yield
       AmqpProperties(

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
@@ -50,6 +50,7 @@ class AmqpPropertiesSpec extends FlatSpecLike with Matchers with AmqpPropertiesA
                      None,
                      None,
                      None,
+                     None,
                      Map.empty[String, AmqpFieldValue]))
   }
 
@@ -185,6 +186,7 @@ trait AmqpPropertiesArbitraries extends PropertyChecks {
       expiration      <- Gen.option(Gen.alphaNumStr)
       replyTo         <- Gen.option(Gen.alphaNumStr)
       clusterId       <- Gen.option(Gen.alphaNumStr)
+      timestamp       <- Gen.option(dateVal.arbitrary.map(_.toValueWriterCompatibleJava))
       headers         <- Gen.mapOf[String, AmqpFieldValue](headersGen)
     } yield
       AmqpProperties(
@@ -200,6 +202,7 @@ trait AmqpPropertiesArbitraries extends PropertyChecks {
         expiration,
         replyTo,
         clusterId,
+        timestamp,
         headers
       )
   }


### PR DESCRIPTION
Noticed there wasn't support for the amqp property `timestamp`. Adding it in.