### PR TITLE
[issue 300] Support sending a `Reject` result in response to a message

### DIFF
--- a/core/src/main/scala-2.13/dev/profunktor/fs2rabbit/javaConversion.scala
+++ b/core/src/main/scala-2.13/dev/profunktor/fs2rabbit/javaConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 ProfunKtor
+ * Copyright 2017-2020 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
@@ -31,6 +31,7 @@ case class Fs2RabbitConfig(
     username: Option[String],
     password: Option[String],
     requeueOnNack: Boolean,
+    requeueOnReject: Boolean,
     internalQueueSize: Option[Int],
     automaticRecovery: Boolean
 )
@@ -45,6 +46,7 @@ object Fs2RabbitConfig {
       username: Option[String],
       password: Option[String],
       requeueOnNack: Boolean,
+      requeueOnReject: Boolean,
       internalQueueSize: Option[Int],
       automaticRecovery: Boolean = true
   ): Fs2RabbitConfig = Fs2RabbitConfig(
@@ -55,6 +57,7 @@ object Fs2RabbitConfig {
     username = username,
     password = password,
     requeueOnNack = requeueOnNack,
+    requeueOnReject = requeueOnReject,
     internalQueueSize = internalQueueSize,
     automaticRecovery = automaticRecovery
   )

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -79,8 +79,9 @@ object model {
   sealed trait AckResult extends Product with Serializable
 
   object AckResult {
-    final case class Ack(deliveryTag: DeliveryTag)  extends AckResult
-    final case class NAck(deliveryTag: DeliveryTag) extends AckResult
+    final case class Ack(deliveryTag: DeliveryTag)    extends AckResult
+    final case class NAck(deliveryTag: DeliveryTag)   extends AckResult
+    final case class Reject(deliveryTag: DeliveryTag) extends AckResult
   }
 
   /**

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/ConsumingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/ConsumingProgram.scala
@@ -85,6 +85,9 @@ case class WrapperConsumingProgram[F[_]: Effect] private (
   override def basicNack(channel: AMQPChannel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit] =
     consume.basicNack(channel, tag, multiple, requeue)
 
+  override def basicReject(channel: AMQPChannel, tag: DeliveryTag, requeue: Boolean): F[Unit] =
+    consume.basicReject(channel, tag, requeue)
+
   override def basicQos(channel: AMQPChannel, basicQos: BasicQos): F[Unit] =
     consume.basicQos(channel, basicQos)
 

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
@@ -35,6 +35,7 @@ object IOAckerConsumer extends IOApp {
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
+    requeueOnReject = false,
     internalQueueSize = Some(500),
     automaticRecovery = true
   )

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -40,6 +40,7 @@ object MonixAutoAckConsumer extends TaskApp {
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
+    requeueOnReject = false,
     internalQueueSize = Some(500),
     automaticRecovery = true
   )

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/RPCDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/RPCDemo.scala
@@ -45,6 +45,7 @@ object RPCDemo extends IOApp {
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
+    requeueOnReject = false,
     internalQueueSize = Some(500),
     automaticRecovery = true
   )

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/ZIOAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/ZIOAutoAckConsumer.scala
@@ -37,6 +37,7 @@ object ZIOAutoAckConsumer extends CatsApp {
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
+    requeueOnReject = false,
     internalQueueSize = Some(500)
   )
 

--- a/site/docs/client.md
+++ b/site/docs/client.md
@@ -48,6 +48,7 @@ class Demo extends IOApp {
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
+    requeueOnReject = false,
     internalQueueSize = Some(500)
   )
 

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -25,6 +25,7 @@ val config = Fs2RabbitConfig(
   ssl = false,
   connectionTimeout = 3,
   requeueOnNack = false,
+  requeueOnReject = false,
   internalQueueSize = Some(500),
   automaticRecovery = true
 )

--- a/site/docs/examples/sample-acker.md
+++ b/site/docs/examples/sample-acker.md
@@ -111,6 +111,7 @@ object IOAckerConsumer extends IOApp {
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
+    requeueOnReject = false,
     internalQueueSize = Some(500),
     automaticRecovery = true
   )

--- a/site/docs/examples/sample-autoack.md
+++ b/site/docs/examples/sample-autoack.md
@@ -101,6 +101,7 @@ object MonixAutoAckConsumer extends TaskApp {
     ssl = false,
     connectionTimeout = 3,
     requeueOnNack = false,
+    requeueOnReject = false,
     internalQueueSize = Some(500),
     automaticRecovery = true
   )

--- a/test-support/src/main/scala/dev/profunktor/fs2rabbit/DockerRabbit.scala
+++ b/test-support/src/main/scala/dev/profunktor/fs2rabbit/DockerRabbit.scala
@@ -62,6 +62,7 @@ trait DockerRabbit extends BeforeAndAfterAll { self: Suite =>
     username = Some(rabbitUser),
     password = Some(rabbitPassword),
     requeueOnNack = false,
+    requeueOnReject = false,
     internalQueueSize = Some(500)
   )
 


### PR DESCRIPTION
Closes https://github.com/profunktor/fs2-rabbit/issues/300

* Added a `Reject` case to `AckResult`.
* Added `basicReject` to `Consume` and the necessary implementations to the other traits and classes.
* Added a `requeueOnReject` boolean parameter to `Fs2RabbitConfig`
* Added tests for requeue and non-requeue on reject