### PR TITLE
Cats instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,11 @@ val commonSettings = Seq(
       </developers>
 )
 
-def CoreDependencies(scalaVersionStr: String): Seq[ModuleID] = Seq(Libraries.logback % Test)
+def CoreDependencies(scalaVersionStr: String): Seq[ModuleID] =
+  Seq(
+    Libraries.scodecCats,
+    Libraries.logback % Test
+  )
 
 def JsonDependencies(scalaVersionStr: String): Seq[ModuleID] =
   Seq(
@@ -83,6 +87,14 @@ def ExamplesDependencies(scalaVersionStr: String): Seq[ModuleID] =
     Libraries.zioCore,
     Libraries.zioCats
   )
+
+def TestKitDependencies(scalaVersionStr: String): Seq[ModuleID] = Seq(Libraries.scalaCheck)
+
+def TestsDependencies(scalaVersionStr: String): Seq[ModuleID] = Seq(
+  Libraries.disciplineScalaCheck % Test,
+  Libraries.catsLaws % Test,
+  Libraries.catsKernelLaws % Test,
+)
 
 lazy val noPublish = Seq(
   publish := {},
@@ -116,8 +128,9 @@ lazy val tests = project
   .settings(commonSettings: _*)
   .settings(noPublish)
   .enablePlugins(AutomateHeaderPlugin)
+  .settings(libraryDependencies ++= TestsDependencies(scalaVersion.value))
   .settings(parallelExecution in Test := false)
-  .dependsOn(`fs2-rabbit`)
+  .dependsOn(`fs2-rabbit`, `fs2-rabbit-testkit`)
 
 lazy val examples = project
   .in(file("examples"))
@@ -126,6 +139,13 @@ lazy val examples = project
   .settings(noPublish)
   .enablePlugins(AutomateHeaderPlugin)
   .dependsOn(`fs2-rabbit`, `fs2-rabbit-circe`)
+
+lazy val `fs2-rabbit-testkit` = project
+  .in(file("testkit"))
+  .settings(commonSettings: _*)
+  .settings(libraryDependencies ++= TestKitDependencies(scalaVersion.value))
+  .enablePlugins(AutomateHeaderPlugin)
+  .dependsOn(`fs2-rabbit`)
 
 lazy val microsite = project
   .in(file("site"))

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,8 @@ val commonSettings = Seq(
       Libraries.catsEffect,
       Libraries.fs2Core,
       Libraries.scalaTest  % Test,
-      Libraries.scalaCheck % Test
+      Libraries.scalaCheck % Test,
+      Libraries.scalaTestPlusScalaCheck % Test
     )
   },
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpFieldValueSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpFieldValueSpec.scala
@@ -22,9 +22,11 @@ import java.time.Instant
 import com.rabbitmq.client.impl.{ValueReader, ValueWriter}
 import dev.profunktor.fs2rabbit.model.AmqpFieldValue._
 import dev.profunktor.fs2rabbit.model.{AmqpFieldValue, ShortString}
-import org.scalatest.{Assertion, FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
 
-class AmqpFieldValueSpec extends FlatSpecLike with Matchers with AmqpPropertiesArbitraries {
+class AmqpFieldValueSpec extends AnyFlatSpecLike with Matchers with AmqpPropertiesArbitraries {
 
   it should "convert from and to Java primitive header values" in {
     val intVal    = IntVal(1)

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
@@ -23,11 +23,12 @@ import dev.profunktor.fs2rabbit.model.AmqpFieldValue._
 import dev.profunktor.fs2rabbit.model.{AmqpFieldValue, AmqpProperties, DeliveryMode, ShortString}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck._
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 import scodec.bits.ByteVector
 
-class AmqpPropertiesSpec extends FlatSpecLike with Matchers with AmqpPropertiesArbitraries {
+class AmqpPropertiesSpec extends AnyFlatSpecLike with Matchers with AmqpPropertiesArbitraries {
 
   it should s"convert from and to Java AMQP.BasicProperties" in {
     forAll { amqpProperties: AmqpProperties =>

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/SafeArgSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/SafeArgSpec.scala
@@ -17,10 +17,11 @@
 package dev.profunktor.fs2rabbit
 
 import org.scalacheck.Gen
-import org.scalatest.{Assertion, FunSuite}
+import org.scalatest.Assertion
+import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 
-class SafeArgSpec extends FunSuite with PropertyChecks {
+class SafeArgSpec extends AnyFunSuite with PropertyChecks {
 
   import arguments._
 

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/effects/EnvelopeDecoderSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/effects/EnvelopeDecoderSpec.scala
@@ -23,7 +23,7 @@ import cats.effect.{IO, SyncIO}
 import cats.instances.either._
 import cats.instances.try_._
 import dev.profunktor.fs2rabbit.model.{AmqpEnvelope, AmqpProperties, DeliveryTag, ExchangeName, RoutingKey}
-import org.scalatest.AsyncFunSuite
+import org.scalatest.funsuite.AsyncFunSuite
 
 import scala.util.Try
 

--- a/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonDecoderSpec.scala
+++ b/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonDecoderSpec.scala
@@ -19,10 +19,11 @@ package dev.profunktor.fs2rabbit.json
 import cats.syntax.functor._
 import dev.profunktor.fs2rabbit.model.{AmqpEnvelope, AmqpProperties, DeliveryTag, ExchangeName, RoutingKey}
 import io.circe._
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.{ScalaCheckPropertyChecks => PropertyChecks}
 
-class Fs2JsonDecoderSpec extends Fs2JsonDecoderFixture with FlatSpecLike with Matchers {
+class Fs2JsonDecoderSpec extends Fs2JsonDecoderFixture with AnyFlatSpecLike with Matchers {
 
   import io.circe.generic.auto._
 

--- a/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonEncoderSpec.scala
+++ b/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonEncoderSpec.scala
@@ -20,9 +20,10 @@ import dev.profunktor.fs2rabbit.model.{AmqpMessage, AmqpProperties}
 import io.circe.Printer
 import io.circe.generic.auto._
 import io.circe.syntax._
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class Fs2JsonEncoderSpec extends FlatSpecLike with Matchers {
+class Fs2JsonEncoderSpec extends AnyFlatSpecLike with Matchers {
 
   case class Address(number: Int, streetName: String)
   case class Person(name: String, address: Address)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,6 +3,7 @@ import sbt._
 object Dependencies {
 
   object Version {
+    val cats       = "2.1.1"
     val catsEffect = "2.1.2"
     val fs2        = "2.3.0"
     val circe      = "0.13.0"
@@ -11,13 +12,15 @@ object Dependencies {
     val monix      = "3.1.0"
     val zio        = "1.0.0-RC19-2"
     val zioCats    = "2.0.0.0-RC14"
+    val scodec     = "1.0.0"
 
     val kindProjector    = "0.11.0"
     val betterMonadicFor = "0.3.1"
 
-    val scalaTest  = "3.1.2"
-    val scalaCheck = "1.14.3"
+    val scalaTest               = "3.1.2"
+    val scalaCheck              = "1.14.3"
     val scalaTestPlusScalaCheck = "3.1.2.0"
+    val disciplineScalaCheck    = "1.0.1"
   }
 
   object Libraries {
@@ -26,6 +29,7 @@ object Dependencies {
     lazy val amqpClient = "com.rabbitmq"  % "amqp-client"  % Version.amqpClient
     lazy val catsEffect = "org.typelevel" %% "cats-effect" % Version.catsEffect
     lazy val fs2Core    = "co.fs2"        %% "fs2-core"    % Version.fs2
+    lazy val scodecCats = "org.scodec"    %% "scodec-cats" % Version.scodec
 
     // Compiler
     lazy val kindProjector    = "org.typelevel" % "kind-projector"      % Version.kindProjector cross CrossVersion.full
@@ -43,9 +47,12 @@ object Dependencies {
     lazy val circeParser  = circe("circe-parser")
 
     // Scala test libraries
-    lazy val scalaTest                = "org.scalatest"     %% "scalatest"        % Version.scalaTest
-    lazy val scalaCheck               = "org.scalacheck"    %% "scalacheck"       % Version.scalaCheck
-    lazy val scalaTestPlusScalaCheck  = "org.scalatestplus" %% "scalacheck-1-14"  % Version.scalaTestPlusScalaCheck
+    lazy val scalaTest                = "org.scalatest"     %% "scalatest"            % Version.scalaTest
+    lazy val scalaCheck               = "org.scalacheck"    %% "scalacheck"           % Version.scalaCheck
+    lazy val scalaTestPlusScalaCheck  = "org.scalatestplus" %% "scalacheck-1-14"      % Version.scalaTestPlusScalaCheck
+    lazy val disciplineScalaCheck     = "org.typelevel"     %% "discipline-scalatest" % Version.disciplineScalaCheck
+    lazy val catsLaws                 = "org.typelevel"     %% "cats-laws"            % Version.cats
+    lazy val catsKernelLaws           = "org.typelevel"     %% "cats-kernel-laws"     % Version.cats
   }
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,8 +15,9 @@ object Dependencies {
     val kindProjector    = "0.11.0"
     val betterMonadicFor = "0.3.1"
 
-    val scalaTest  = "3.0.8"
+    val scalaTest  = "3.1.2"
     val scalaCheck = "1.14.3"
+    val scalaTestPlusScalaCheck = "3.1.2.0"
   }
 
   object Libraries {
@@ -42,8 +43,9 @@ object Dependencies {
     lazy val circeParser  = circe("circe-parser")
 
     // Scala test libraries
-    lazy val scalaTest  = "org.scalatest"  %% "scalatest"  % Version.scalaTest
-    lazy val scalaCheck = "org.scalacheck" %% "scalacheck" % Version.scalaCheck
+    lazy val scalaTest                = "org.scalatest"     %% "scalatest"        % Version.scalaTest
+    lazy val scalaCheck               = "org.scalacheck"    %% "scalacheck"       % Version.scalaCheck
+    lazy val scalaTestPlusScalaCheck  = "org.scalatestplus" %% "scalacheck-1-14"  % Version.scalaTestPlusScalaCheck
   }
 
 }

--- a/testkit/src/main/scala/dev/profunktor/fs2rabbit/testkit/package.scala
+++ b/testkit/src/main/scala/dev/profunktor/fs2rabbit/testkit/package.scala
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2017-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.fs2rabbit
+
+import java.time.Instant
+import java.util.Date
+
+import dev.profunktor.fs2rabbit.model.AmqpFieldValue._
+import dev.profunktor.fs2rabbit.model._
+import org.scalacheck.Arbitrary._
+import org.scalacheck._
+import org.scalacheck.rng.Seed
+import scodec.bits.ByteVector
+
+package object testkit {
+  implicit def arbAmqpEnvelope[A](implicit A: Arbitrary[A]): Arbitrary[AmqpEnvelope[A]] = Arbitrary {
+    for {
+      deliveryTag <- arbitrary[DeliveryTag]
+      payload     <- arbitrary[A]
+      props       <- arbitrary[AmqpProperties]
+      exchange    <- arbitrary[ExchangeName]
+      routingKey  <- arbitrary[RoutingKey]
+      redelivered <- arbitrary[Boolean]
+    } yield AmqpEnvelope(deliveryTag, payload, props, exchange, routingKey, redelivered)
+  }
+  implicit def cogenAmqpEnvelope[A: Cogen]: Cogen[AmqpEnvelope[A]] =
+    Cogen[(DeliveryTag, A, ExchangeName, RoutingKey, Boolean)].contramap { a =>
+      (a.deliveryTag, a.payload, a.exchangeName, a.routingKey, a.redelivered)
+    }
+
+  implicit val arbAmqpProperties: Arbitrary[AmqpProperties] = Arbitrary {
+    import InstantArbitraries._
+    for {
+      contentType     <- Gen.option(Gen.const("application/json"))
+      contentEncoding <- Gen.option(Gen.const("UTF-8"))
+      priority        <- Gen.option(arbitrary[Int])
+      deliveryMode    <- Gen.option(arbitrary[DeliveryMode])
+      correlationId   <- Gen.option(Gen.identifier)
+      messageId       <- Gen.option(Gen.identifier)
+      tpe             <- Gen.option(arbitrary[String])
+      userId          <- Gen.option(Gen.identifier)
+      appId           <- Gen.option(Gen.identifier)
+      expiration      <- Gen.option(arbitrary[String])
+      replyTo         <- Gen.option(Gen.identifier)
+      clusterId       <- Gen.option(Gen.identifier)
+      timestamp       <- Gen.option(arbitrary[Instant])
+      headers         <- arbitrary[Map[String, AmqpFieldValue]]
+    } yield
+      AmqpProperties(
+        contentType = contentType,
+        contentEncoding = contentEncoding,
+        priority = priority,
+        deliveryMode = deliveryMode,
+        correlationId = correlationId,
+        messageId = messageId,
+        `type` = tpe,
+        userId = userId,
+        appId = appId,
+        expiration = expiration,
+        replyTo = replyTo,
+        clusterId = clusterId,
+        timestamp = timestamp,
+        headers = headers,
+      )
+  }
+  implicit val cogenAmqpProperties: Cogen[AmqpProperties] =
+    Cogen.it { p =>
+      (p.contentType ++ p.contentEncoding ++ p.correlationId ++ p.messageId ++ p.userId ++ p.appId).iterator
+    }
+
+  implicit val arbDeliveryTag: Arbitrary[DeliveryTag] = Arbitrary(Gen.chooseNum(1L, Long.MaxValue).map(DeliveryTag(_)))
+  implicit val cogenDeliveryTag: Cogen[DeliveryTag]   = Cogen[Long].contramap(_.value)
+
+  implicit val arbExchangeName: Arbitrary[ExchangeName] = Arbitrary(Gen.asciiPrintableStr.map(ExchangeName(_)))
+  implicit val cogenExchangeName: Cogen[ExchangeName]   = Cogen[String].contramap(_.value)
+
+  implicit val arbRoutingKey: Arbitrary[RoutingKey] = Arbitrary(Gen.asciiPrintableStr.map(RoutingKey(_)))
+  implicit val cogenRoutingKey: Cogen[RoutingKey]   = Cogen[String].contramap(_.value)
+
+  implicit val arbQueueName: Arbitrary[QueueName] = Arbitrary(Gen.asciiPrintableStr.map(QueueName(_)))
+  implicit val cogenQueueName: Cogen[QueueName]   = Cogen[String].contramap(_.value)
+
+  implicit val arbConsumerTag: Arbitrary[ConsumerTag] = Arbitrary(Gen.asciiPrintableStr.map(ConsumerTag(_)))
+  implicit val cogenConsumerTag: Cogen[ConsumerTag]   = Cogen[String].contramap(_.value)
+
+  implicit val arbShortString: Arbitrary[ShortString] = Arbitrary {
+    Gen
+      .listOfN(ShortString.MaxByteLength / 3, arbitrary[Char])
+      .map(_.mkString)
+      .suchThat { str =>
+        ShortString.from(str).isDefined
+      }
+      .map(ShortString.unsafeFrom)
+  }
+  implicit val cogenShortString: Cogen[ShortString] = Cogen[String].contramap(_.str)
+
+  implicit val arbTableVal: Arbitrary[TableVal] = Arbitrary {
+    Gen.lzy(arbitrary[Map[ShortString, AmqpFieldValue]].map(TableVal(_)))
+  }
+  implicit val cogenTableVal: Cogen[TableVal] = Cogen[Map[ShortString, AmqpFieldValue]].contramap(_.value)
+
+  implicit val arbByteArrayVal: Arbitrary[ByteArrayVal] = Arbitrary(
+    arbitrary[Array[Byte]].map(ByteVector(_)).map(ByteArrayVal(_)))
+  implicit val cogenByteArrayVal: Cogen[ByteArrayVal] = Cogen[Array[Byte]].contramap(_.value.toArray)
+
+  implicit val arbArrayVal: Arbitrary[ArrayVal] = Arbitrary {
+    Gen.lzy(arbitrary[Vector[AmqpFieldValue]].map(ArrayVal(_)))
+  }
+  implicit val cogenArrayVal: Cogen[ArrayVal] = Cogen[Vector[AmqpFieldValue]].contramap(_.value)
+
+  implicit val arbDeliveryMode: Arbitrary[DeliveryMode] = Arbitrary(
+    Gen.oneOf(DeliveryMode.NonPersistent, DeliveryMode.Persistent))
+  implicit val cogenDeliveryMode: Cogen[DeliveryMode] = Cogen[Int].contramap(_.value)
+
+  implicit val arbTimestampVal: Arbitrary[TimestampVal] = Arbitrary(arbitrary[Date].map(TimestampVal.from))
+  implicit val cogenTimestampVal: Cogen[TimestampVal] =
+    Cogen[Long].contramap(_.instantWithOneSecondAccuracy.getEpochSecond)
+
+  implicit val arbDecimalVal: Arbitrary[DecimalVal] = Arbitrary {
+    val safeBigDecimalGen: Gen[BigDecimal] =
+      for {
+        unscaled <- arbitrary[Int]
+        scale    <- Gen.chooseNum(0, 255)
+      } yield BigDecimal(BigInt(unscaled), scale)
+    safeBigDecimalGen.suchThat(DecimalVal.from(_).isDefined).map(DecimalVal.unsafeFrom)
+  }
+  implicit val cogenDecimalVal: Cogen[DecimalVal] = Cogen[BigDecimal].contramap(_.sizeLimitedBigDecimal)
+
+  implicit val arbByteVal: Arbitrary[ByteVal] = Arbitrary(arbitrary[Byte].map(ByteVal(_)))
+  implicit val cogenByteVal: Cogen[ByteVal]   = Cogen[Byte].contramap(_.value)
+
+  implicit val arbDoubleVal: Arbitrary[DoubleVal] = Arbitrary(arbitrary[Double].map(DoubleVal(_)))
+  implicit val cogenDoubleVal: Cogen[DoubleVal]   = Cogen[Double].contramap(_.value)
+
+  implicit val arbFloatVal: Arbitrary[FloatVal] = Arbitrary(arbitrary[Float].map(FloatVal(_)))
+  implicit val cogenFloatVal: Cogen[FloatVal]   = Cogen[Float].contramap(_.value)
+
+  implicit val arbShortVal: Arbitrary[ShortVal] = Arbitrary(arbitrary[Short].map(ShortVal(_)))
+  implicit val cogenShortVal: Cogen[ShortVal]   = Cogen[Short].contramap(_.value)
+
+  implicit val arbBooleanVal: Arbitrary[BooleanVal] = Arbitrary(arbitrary[Boolean].map(BooleanVal(_)))
+  implicit val cogenBooleanVal: Cogen[BooleanVal]   = Cogen[Boolean].contramap(_.value)
+
+  implicit val arbIntVal: Arbitrary[IntVal] = Arbitrary(arbitrary[Int].map(IntVal(_)))
+  implicit val cogenIntVal: Cogen[IntVal]   = Cogen[Int].contramap(_.value)
+
+  implicit val arbLongVal: Arbitrary[LongVal] = Arbitrary(arbitrary[Long].map(LongVal(_)))
+  implicit val cogenLongVal: Cogen[LongVal]   = Cogen[Long].contramap(_.value)
+
+  implicit val arbStringVal: Arbitrary[StringVal] = Arbitrary(arbitrary[String].map(StringVal(_)))
+  implicit val cogenStringVal: Cogen[StringVal]   = Cogen[String].contramap(_.value)
+
+  implicit val arbNullVal: Arbitrary[NullVal.type] = Arbitrary(Gen.const(NullVal))
+  implicit val cogenNullVal: Cogen[NullVal.type]   = Cogen[Long].contramap(_ => 0L)
+
+  implicit val arbAmqpFieldValue: Arbitrary[AmqpFieldValue] = Arbitrary {
+    Gen.sized { size =>
+      val effectiveSize = size min 5
+      Gen.resize(
+        0 max (effectiveSize - 1),
+        Gen.lzy {
+          Gen.oneOf(
+            arbTableVal.arbitrary,
+            arbByteArrayVal.arbitrary,
+            arbArrayVal.arbitrary,
+            arbTimestampVal.arbitrary,
+            arbDecimalVal.arbitrary,
+            arbByteVal.arbitrary,
+            arbDoubleVal.arbitrary,
+            arbFloatVal.arbitrary,
+            arbShortVal.arbitrary,
+            arbBooleanVal.arbitrary,
+            arbIntVal.arbitrary,
+            arbLongVal.arbitrary,
+            arbStringVal.arbitrary,
+            arbNullVal.arbitrary,
+          )
+        }
+      )
+    }
+  }
+
+  implicit def cogenAmqpFieldValue: Cogen[AmqpFieldValue] =
+    Cogen { (seed: Seed, t: AmqpFieldValue) =>
+      t match {
+        case a: TableVal     => Cogen[TableVal].perturb(seed, a)
+        case a: ByteArrayVal => Cogen[ByteArrayVal].perturb(seed, a)
+        case a: ArrayVal     => Cogen[ArrayVal].perturb(seed, a)
+        case a: TimestampVal => Cogen[TimestampVal].perturb(seed, a)
+        case a: DecimalVal   => Cogen[DecimalVal].perturb(seed, a)
+        case a: ByteVal      => Cogen[ByteVal].perturb(seed, a)
+        case a: DoubleVal    => Cogen[DoubleVal].perturb(seed, a)
+        case a: FloatVal     => Cogen[FloatVal].perturb(seed, a)
+        case a: ShortVal     => Cogen[ShortVal].perturb(seed, a)
+        case a: BooleanVal   => Cogen[BooleanVal].perturb(seed, a)
+        case a: IntVal       => Cogen[IntVal].perturb(seed, a)
+        case a: LongVal      => Cogen[LongVal].perturb(seed, a)
+        case a: StringVal    => Cogen[StringVal].perturb(seed, a)
+        case a: NullVal.type => Cogen[NullVal.type].perturb(seed, a)
+      }
+    }
+}
+
+package testkit {
+  trait InstantArbitraries {
+    implicit val arbInstantWithSecondPrecision: Arbitrary[Instant] = Arbitrary {
+      Gen.choose(Instant.MIN, Instant.MAX)(Gen.Choose.xmap[Long, Instant](Instant.ofEpochSecond, _.getEpochSecond))
+    }
+    implicit val cogenInstantWithSecondPrecision: Cogen[Instant] = Cogen[Long].contramap(_.getEpochSecond)
+  }
+
+  object InstantArbitraries extends InstantArbitraries
+}

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/BaseSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/BaseSpec.scala
@@ -18,7 +18,10 @@ package dev.profunktor.fs2rabbit
 
 import cats.effect.{ContextShift, IO, Timer}
 import dev.profunktor.fs2rabbit.effects.Log
-import org.scalatest.{AsyncFlatSpecLike, EitherValues, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AsyncFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
 import scala.concurrent.ExecutionContext
 
 trait BaseSpec extends AsyncFlatSpecLike with Matchers with EitherValues {

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/CommutativeSemigroupInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/CommutativeSemigroupInstancesSpec.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.fs2rabbit.laws
+
+import cats.kernel.laws.discipline.CommutativeSemigroupTests
+import dev.profunktor.fs2rabbit.model.DeliveryTag
+import dev.profunktor.fs2rabbit.testkit._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.typelevel.discipline.scalatest.FunSpecDiscipline
+
+class CommutativeSemigroupInstancesSpec extends AnyFunSpec with FunSpecDiscipline with ScalaCheckPropertyChecks {
+  checkAll("DeliveryTag.CommutativeSemigroupLaws", CommutativeSemigroupTests[DeliveryTag].commutativeSemigroup)
+}

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/EqInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/EqInstancesSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.fs2rabbit.laws
+
+import cats.implicits._
+import cats.kernel.laws.discipline.EqTests
+import dev.profunktor.fs2rabbit.model.AmqpFieldValue._
+import dev.profunktor.fs2rabbit.model._
+import dev.profunktor.fs2rabbit.testkit._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.typelevel.discipline.scalatest.FunSpecDiscipline
+
+class EqInstancesSpec extends AnyFunSpec with FunSpecDiscipline with ScalaCheckPropertyChecks {
+  checkAll("AmqpEnvelope[String].EqLaws", EqTests[AmqpEnvelope[String]].eqv)
+  checkAll("AmqpProperties.EqLaws", EqTests[AmqpProperties].eqv)
+  checkAll("TableVal.EqLaws", EqTests[TableVal].eqv)
+  checkAll("ByteArrayVal.EqLaws", EqTests[ByteArrayVal].eqv)
+  checkAll("ArrayVal.EqLaws", EqTests[ArrayVal].eqv)
+  checkAll("AmqpFieldValue.EqLaws", EqTests[AmqpFieldValue].eqv)
+}

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/OrderInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/OrderInstancesSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.fs2rabbit.laws
+
+import java.time.Instant
+
+import cats._
+import cats.implicits._
+import cats.kernel.laws.discipline._
+import dev.profunktor.fs2rabbit.model.AmqpFieldValue._
+import dev.profunktor.fs2rabbit.model._
+import dev.profunktor.fs2rabbit.testkit._
+import org.scalacheck.Arbitrary._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.typelevel.discipline.scalatest.FunSpecDiscipline
+
+class OrderInstancesSpec
+    extends AnyFunSpec
+    with FunSpecDiscipline
+    with ScalaCheckPropertyChecks
+    with InstantArbitraries {
+  implicit val orderInstant: Order[Instant] = Order.by(_.getEpochSecond)
+
+  checkAll("ExchangeName.OrderLaws", OrderTests[ExchangeName].order)
+  checkAll("QueueName.OrderLaws", OrderTests[QueueName].order)
+  checkAll("RoutingKey.OrderLaws", OrderTests[RoutingKey].order)
+  checkAll("DeliveryTag.OrderLaws", OrderTests[DeliveryTag].order)
+  checkAll("ConsumerTag.OrderLaws", OrderTests[ConsumerTag].order)
+  checkAll("Instant.OrderLaws", OrderTests[Instant](instantOrderWithSecondPrecision).order)
+  checkAll("DeliveryMode.OrderLaws", OrderTests[DeliveryMode].order)
+  checkAll("ShortString.OrderLaws", OrderTests[ShortString].order)
+  checkAll("TimestampVal.OrderLaws", OrderTests[TimestampVal].order)
+  checkAll("DecimalVal.OrderLaws", OrderTests[DecimalVal].order)
+  checkAll("ByteVal.OrderLaws", OrderTests[ByteVal].order)
+  checkAll("DoubleVal.OrderLaws", OrderTests[DoubleVal].order)
+  checkAll("FloatVal.OrderLaws", OrderTests[FloatVal].order)
+  checkAll("ShortVal.OrderLaws", OrderTests[ShortVal].order)
+  checkAll("BooleanVal.OrderLaws", OrderTests[BooleanVal].order)
+  checkAll("IntVal.OrderLaws", OrderTests[IntVal].order)
+  checkAll("LongVal.OrderLaws", OrderTests[LongVal].order)
+  checkAll("StringVal.OrderLaws", OrderTests[StringVal].order)
+  checkAll("NullVal.OrderLaws", OrderTests[NullVal.type].order)
+}

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/TraverseInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/TraverseInstancesSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.fs2rabbit.laws
+
+import cats.implicits._
+import cats.laws.discipline.TraverseTests
+import dev.profunktor.fs2rabbit.model._
+import dev.profunktor.fs2rabbit.testkit._
+import org.scalacheck.Arbitrary._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.typelevel.discipline.scalatest.FunSpecDiscipline
+
+class TraverseInstancesSpec extends AnyFunSpec with FunSpecDiscipline with ScalaCheckPropertyChecks {
+  checkAll("AmqpEnvelope.TraverseLaws", TraverseTests[AmqpEnvelope].traverse[Int, Int, Int, Int, Option, Option])
+}


### PR DESCRIPTION
This PR addresses #314 by adding a `Traverse[AmqpEnvelope]`, `CommutativeSemigroup[DeliveryTag]`, and `Order` or `Eq` instances for most of the types in `dev.profunktor.fs2rabbit.model`. The lawfulness of all the instances is tested using Discipline.

I also exposed the ScalaCheck `Arbitrary` and `Cogen` instances used to test the cats instances in a new `testkit` module. I originally wrote several of the `Arbitrary` instances for property testing in a downstream app, and it would be nice to be able to reuse them in both places.

`Order` instances are provided where the underlying types allow, with `Eq` instances otherwise. In particular, the scodec, `Map`, and `Array`-based types are `Eq`-only.

The idea behind the `CommutativeSemigroup[DeliveryTag]` instance is to use it for acknowledging multiple messages. The instance takes the max of the `DeliveryTag`'s underlying values.
