### PR TITLE
Add optional `MetricsCollector` to the client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,9 @@ def ExamplesDependencies(scalaVersionStr: String): List[ModuleID] =
     Libraries.logback % "runtime",
     Libraries.monix,
     Libraries.zioCore,
-    Libraries.zioCats
+    Libraries.zioCats,
+    Libraries.dropwizard,
+    Libraries.dropwizardJmx
   )
 
 def TestKitDependencies(scalaVersionStr: String): List[ModuleID] = List(Libraries.scalaCheck)

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
@@ -151,10 +151,9 @@ class RabbitClient[F[_]: Concurrent] private[fs2rabbit] (
       listener
     )
 
-  def createRoutingPublisher[A](exchangeName: ExchangeName)(
-      implicit
-      channel: AMQPChannel,
-      encoder: MessageEncoder[F, A]): F[RoutingKey => A => F[Unit]] =
+  def createRoutingPublisher[A](
+      exchangeName: ExchangeName
+  )(implicit channel: AMQPChannel, encoder: MessageEncoder[F, A]): F[RoutingKey => A => F[Unit]] =
     publishingProgram.createRoutingPublisher(channel, exchangeName)
 
   def createRoutingPublisherWithListener[A](
@@ -286,8 +285,7 @@ class RabbitClient[F[_]: Concurrent] private[fs2rabbit] (
       ExchangeUnbindArgs(Map.empty)
     )
 
-  def declareExchange(exchangeName: ExchangeName, exchangeType: ExchangeType)(implicit
-                                                                              channel: AMQPChannel): F[Unit] =
+  def declareExchange(exchangeName: ExchangeName, exchangeType: ExchangeType)(implicit channel: AMQPChannel): F[Unit] =
     declareExchange(
       DeclarationExchangeConfig.default(exchangeName, exchangeType)
     )

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
@@ -18,7 +18,7 @@ package dev.profunktor.fs2rabbit.interpreter
 
 import cats.effect._
 import cats.implicits._
-import com.rabbitmq.client.{DefaultSaslConfig, SaslConfig}
+import com.rabbitmq.client.{DefaultSaslConfig, MetricsCollector, SaslConfig}
 import dev.profunktor.fs2rabbit.algebra._
 import dev.profunktor.fs2rabbit.config.Fs2RabbitConfig
 import dev.profunktor.fs2rabbit.config.declaration.{DeclarationExchangeConfig, DeclarationQueueConfig}
@@ -39,11 +39,12 @@ object RabbitClient {
       sslContext: Option[SSLContext] = None,
       // Unlike SSLContext, SaslConfig is not optional because it is always set
       // by the underlying Java library, even if the user doesn't set it.
-      saslConfig: SaslConfig = DefaultSaslConfig.PLAIN
+      saslConfig: SaslConfig = DefaultSaslConfig.PLAIN,
+      metricsCollector: Option[MetricsCollector] = None
   ): F[RabbitClient[F]] = {
 
     val internalQ         = new LiveInternalQueue[F](config.internalQueueSize.getOrElse(500))
-    val connection        = ConnectionResource.make(config, sslContext, saslConfig)
+    val connection        = ConnectionResource.make(config, sslContext, saslConfig, metricsCollector)
     val consumingProgram  = AckConsumingProgram.make[F](config, internalQ)
     val publishingProgram = PublishingProgram.make[F](blocker)
 
@@ -93,10 +94,9 @@ class RabbitClient[F[_]: Concurrent] private[fs2rabbit] (
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
-  )(
-      implicit channel: AMQPChannel,
-      decoder: EnvelopeDecoder[F, A]
-  ): F[(AckResult => F[Unit], Stream[F, AmqpEnvelope[A]])] =
+  )(implicit
+    channel: AMQPChannel,
+    decoder: EnvelopeDecoder[F, A]): F[(AckResult => F[Unit], Stream[F, AmqpEnvelope[A]])] =
     consumingProgram.createAckerConsumer(
       channel,
       queueName,
@@ -117,9 +117,9 @@ class RabbitClient[F[_]: Concurrent] private[fs2rabbit] (
     )
 
   def createPublisher[A](exchangeName: ExchangeName, routingKey: RoutingKey)(
-      implicit channel: AMQPChannel,
-      encoder: MessageEncoder[F, A]
-  ): F[A => F[Unit]] =
+      implicit
+      channel: AMQPChannel,
+      encoder: MessageEncoder[F, A]): F[A => F[Unit]] =
     publishingProgram.createPublisher(channel, exchangeName, routingKey)
 
   def createPublisherWithListener[A](
@@ -136,16 +136,15 @@ class RabbitClient[F[_]: Concurrent] private[fs2rabbit] (
       listener
     )
 
-  def createBasicPublisher[A](
-      implicit channel: AMQPChannel,
-      encoder: MessageEncoder[F, A]
-  ): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
+  def createBasicPublisher[A](implicit
+                              channel: AMQPChannel,
+                              encoder: MessageEncoder[F, A]): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
     publishingProgram.createBasicPublisher(channel)
 
   def createBasicPublisherWithListener[A](flag: PublishingFlag, listener: PublishReturn => F[Unit])(
-      implicit channel: AMQPChannel,
-      encoder: MessageEncoder[F, A]
-  ): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
+      implicit
+      channel: AMQPChannel,
+      encoder: MessageEncoder[F, A]): F[(ExchangeName, RoutingKey, A) => F[Unit]] =
     publishingProgram.createBasicPublisherWithListener(
       channel,
       flag,
@@ -153,9 +152,9 @@ class RabbitClient[F[_]: Concurrent] private[fs2rabbit] (
     )
 
   def createRoutingPublisher[A](exchangeName: ExchangeName)(
-      implicit channel: AMQPChannel,
-      encoder: MessageEncoder[F, A]
-  ): F[RoutingKey => A => F[Unit]] =
+      implicit
+      channel: AMQPChannel,
+      encoder: MessageEncoder[F, A]): F[RoutingKey => A => F[Unit]] =
     publishingProgram.createRoutingPublisher(channel, exchangeName)
 
   def createRoutingPublisherWithListener[A](
@@ -287,9 +286,8 @@ class RabbitClient[F[_]: Concurrent] private[fs2rabbit] (
       ExchangeUnbindArgs(Map.empty)
     )
 
-  def declareExchange(exchangeName: ExchangeName, exchangeType: ExchangeType)(
-      implicit channel: AMQPChannel
-  ): F[Unit] =
+  def declareExchange(exchangeName: ExchangeName, exchangeType: ExchangeType)(implicit
+                                                                              channel: AMQPChannel): F[Unit] =
     declareExchange(
       DeclarationExchangeConfig.default(exchangeName, exchangeType)
     )

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/DropwizardMetricsDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/DropwizardMetricsDemo.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.fs2rabbit.examples
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+import cats.data.{Kleisli, NonEmptyList}
+import cats.effect.{Blocker, ExitCode, IO, IOApp, Resource, Sync}
+import cats.implicits._
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.jmx.JmxReporter
+import com.rabbitmq.client.impl.StandardMetricsCollector
+import dev.profunktor.fs2rabbit.config.declaration.{DeclarationExchangeConfig, DeclarationQueueConfig}
+import dev.profunktor.fs2rabbit.config.{Fs2RabbitConfig, Fs2RabbitNodeConfig}
+import dev.profunktor.fs2rabbit.interpreter.RabbitClient
+import dev.profunktor.fs2rabbit.model.AckResult.Ack
+import dev.profunktor.fs2rabbit.model.ExchangeType.Topic
+import dev.profunktor.fs2rabbit.model._
+import fs2._
+
+import scala.concurrent.duration._
+
+object DropwizardMetricsDemo extends IOApp {
+
+  private val config: Fs2RabbitConfig = Fs2RabbitConfig(
+    virtualHost = "/",
+    nodes = NonEmptyList.one(Fs2RabbitNodeConfig(host = "127.0.0.1", port = 5672)),
+    username = Some("guest"),
+    password = Some("guest"),
+    ssl = false,
+    connectionTimeout = 3,
+    requeueOnNack = false,
+    requeueOnReject = false,
+    internalQueueSize = Some(500),
+    automaticRecovery = true
+  )
+
+  private val queueName    = QueueName("testQ")
+  private val exchangeName = ExchangeName("testEX")
+  private val routingKey   = RoutingKey("testRK")
+
+  val simpleMessage = AmqpMessage("Hey!", AmqpProperties.empty)
+
+  implicit val stringMessageEncoder =
+    Kleisli[IO, AmqpMessage[String], AmqpMessage[Array[Byte]]] { s =>
+      s.copy(payload = s.payload.getBytes(UTF_8)).pure[IO]
+    }
+
+  override def run(args: List[String]): IO[ExitCode] = {
+    val registry            = new MetricRegistry
+    val dropwizardCollector = new StandardMetricsCollector(registry)
+
+    val resources = for {
+      blocker <- Blocker[IO]
+      _       <- JmxReporterResource.make[IO](registry)
+      client  <- Resource.liftF(RabbitClient[IO](config, blocker, metricsCollector = Some(dropwizardCollector)))
+      channel <- client.createConnection.flatMap(client.createChannel)
+    } yield (channel, client)
+
+    val program = resources.use {
+      case (channel, client) =>
+        implicit val c = channel
+
+        val setup =
+          for {
+            _                 <- client.declareQueue(DeclarationQueueConfig.default(queueName))
+            _                 <- client.declareExchange(DeclarationExchangeConfig.default(exchangeName, Topic))
+            _                 <- client.bindQueue(queueName, exchangeName, routingKey)
+            (acker, consumer) <- client.createAckerConsumer[String](queueName)
+            publisher         <- client.createPublisher[AmqpMessage[String]](exchangeName, routingKey)
+          } yield (consumer, acker, publisher)
+
+        Stream
+          .eval(setup)
+          .flatTap {
+            case (consumer, acker, publisher) =>
+              Stream(
+                Stream(simpleMessage).evalMap(publisher).repeat.metered(1.second),
+                consumer.through(logPipe).evalMap(acker)
+              ).parJoin(2)
+          }
+          .compile
+          .drain
+    }
+
+    program.as(ExitCode.Success)
+  }
+
+  def logPipe[F[_]: Sync]: Pipe[F, AmqpEnvelope[String], AckResult] =
+    _.evalMap { amqpMsg =>
+      putStrLn(s"Consumed: $amqpMsg").as(Ack(amqpMsg.deliveryTag))
+    }
+
+}
+
+object JmxReporterResource {
+  def make[F[_]: Sync](registry: MetricRegistry): Resource[F, JmxReporter] = {
+    val acquire = Sync[F].delay {
+      val reporter = JmxReporter.forRegistry(registry).inDomain("com.rabbitmq.client.jmx").build
+      reporter.start()
+      reporter
+    }
+
+    val close = (reporter: JmxReporter) => Sync[F].delay(reporter.close()).void
+
+    Resource.make(acquire)(close)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
     val zio        = "1.0.0-RC19-2"
     val zioCats    = "2.0.0.0-RC14"
     val scodec     = "1.0.0"
+    val dropwizard = "4.1.5"
 
     val kindProjector    = "0.11.0"
     val betterMonadicFor = "0.3.1"
@@ -26,20 +27,22 @@ object Dependencies {
   object Libraries {
     def circe(artifact: String): ModuleID = "io.circe" %% artifact % Version.circe
 
-    lazy val amqpClient = "com.rabbitmq"  % "amqp-client"  % Version.amqpClient
+    lazy val amqpClient = "com.rabbitmq"   % "amqp-client" % Version.amqpClient
     lazy val catsEffect = "org.typelevel" %% "cats-effect" % Version.catsEffect
     lazy val fs2Core    = "co.fs2"        %% "fs2-core"    % Version.fs2
     lazy val scodecCats = "org.scodec"    %% "scodec-cats" % Version.scodec
 
     // Compiler
-    lazy val kindProjector    = "org.typelevel" % "kind-projector"      % Version.kindProjector cross CrossVersion.full
-    lazy val betterMonadicFor = "com.olegpy"    %% "better-monadic-for" % Version.betterMonadicFor
+    lazy val kindProjector    = "org.typelevel" % "kind-projector"     % Version.kindProjector cross CrossVersion.full
+    lazy val betterMonadicFor = "com.olegpy"   %% "better-monadic-for" % Version.betterMonadicFor
 
     // Examples
-    lazy val logback = "ch.qos.logback" % "logback-classic"   % Version.logback
-    lazy val monix   = "io.monix"       %% "monix"            % Version.monix
-    lazy val zioCore = "dev.zio"        %% "zio"              % Version.zio
-    lazy val zioCats = "dev.zio"        %% "zio-interop-cats" % Version.zioCats
+    lazy val logback       = "ch.qos.logback"        % "logback-classic"  % Version.logback
+    lazy val monix         = "io.monix"             %% "monix"            % Version.monix
+    lazy val zioCore       = "dev.zio"              %% "zio"              % Version.zio
+    lazy val zioCats       = "dev.zio"              %% "zio-interop-cats" % Version.zioCats
+    lazy val dropwizard    = "io.dropwizard.metrics" % "metrics-core"     % Version.dropwizard
+    lazy val dropwizardJmx = "io.dropwizard.metrics" % "metrics-jmx"      % Version.dropwizard
 
     // Json libraries
     lazy val circeCore    = circe("circe-core")
@@ -47,12 +50,12 @@ object Dependencies {
     lazy val circeParser  = circe("circe-parser")
 
     // Scala test libraries
-    lazy val scalaTest                = "org.scalatest"     %% "scalatest"            % Version.scalaTest
-    lazy val scalaCheck               = "org.scalacheck"    %% "scalacheck"           % Version.scalaCheck
-    lazy val scalaTestPlusScalaCheck  = "org.scalatestplus" %% "scalacheck-1-14"      % Version.scalaTestPlusScalaCheck
-    lazy val disciplineScalaCheck     = "org.typelevel"     %% "discipline-scalatest" % Version.disciplineScalaCheck
-    lazy val catsLaws                 = "org.typelevel"     %% "cats-laws"            % Version.cats
-    lazy val catsKernelLaws           = "org.typelevel"     %% "cats-kernel-laws"     % Version.cats
+    lazy val scalaTest               = "org.scalatest"     %% "scalatest"            % Version.scalaTest
+    lazy val scalaCheck              = "org.scalacheck"    %% "scalacheck"           % Version.scalaCheck
+    lazy val scalaTestPlusScalaCheck = "org.scalatestplus" %% "scalacheck-1-14"      % Version.scalaTestPlusScalaCheck
+    lazy val disciplineScalaCheck    = "org.typelevel"     %% "discipline-scalatest" % Version.disciplineScalaCheck
+    lazy val catsLaws                = "org.typelevel"     %% "cats-laws"            % Version.cats
+    lazy val catsKernelLaws          = "org.typelevel"     %% "cats-kernel-laws"     % Version.cats
   }
 
 }

--- a/site/docs/examples/client-metrics.md
+++ b/site/docs/examples/client-metrics.md
@@ -7,7 +7,7 @@ number: 18
 # Client Metrics
 
 RabbitMQ Java Client supports metrics collection via [Dropwizard](https://www.rabbitmq.com/blog/2016/11/30/metrics-support-in-rabbitmq-java-client-4-0/) or [Micrometer](https://www.rabbitmq.com/blog/2018/04/10/rabbitmq-java-client-metrics-with-micrometer-and-datadog/).
-At the moment of writing both providers are in the `amqp-client` 5.9.0. Just instantiate one as it is shown below.
+At the moment of writing both providers are in the `amqp-client` 5.9.0. You can instantiate one as shown below.
 
 ```scala
 val registry            = new MetricRegistry

--- a/site/docs/examples/client-metrics.md
+++ b/site/docs/examples/client-metrics.md
@@ -1,0 +1,186 @@
+---
+layout: docs
+title:  "Client Metrics"
+number: 18
+---
+
+# Client Metrics
+
+RabbitMQ Java Client supports metrics collection via [Dropwizard](https://www.rabbitmq.com/blog/2016/11/30/metrics-support-in-rabbitmq-java-client-4-0/) or [Micrometer](https://www.rabbitmq.com/blog/2018/04/10/rabbitmq-java-client-metrics-with-micrometer-and-datadog/).
+At the moment of writing both providers are in the `amqp-client` 5.9.0. Just instantiate one as it is shown below.
+
+```scala
+val registry            = new MetricRegistry
+val dropwizardCollector = new StandardMetricsCollector(registry)
+``` 
+
+Now it is ready to use.
+
+```scala
+RabbitClient[IO](config, blocker, metricsCollector = Some(dropwizardCollector))
+```
+
+## Expose via JMX
+
+JMX provides a standard way to access performance metrics of an application. Dropwizard has a module to report metrics
+via JMX with `metrics-jmx` module. Please add it to the list of the dependencies. 
+
+```
+libraryDependencies += "io.dropwizard.metrics" % "metrics-core" % "4.1.5"
+libraryDependencies += "io.dropwizard.metrics" % "metrics-jmx"  % "4.1.5"
+```
+
+It provides `JmxReporter` for the metrics registry. It is a resource. It can be wrapped with acquire-release pattern for
+ease to use. 
+
+```scala
+object JmxReporterResource {
+  def make[F[_]: Sync](registry: MetricRegistry): Resource[F, JmxReporter] = {
+    val acquire = Sync[F].delay {
+      val reporter = JmxReporter.forRegistry(registry).inDomain("com.rabbitmq.client.jmx").build
+      reporter.start()
+      reporter
+    }
+
+    val close = (reporter: JmxReporter) => Sync[F].delay(reporter.close()).void
+
+    Resource.make(acquire)(close)
+  }
+}
+```
+
+Let's initialise the FS2 RabbitMQ client and AMQP channel with metrics.
+
+```scala
+val resources = for {
+  blocker <- Blocker[IO]
+  _       <- JmxReporterResource.make[IO](registry)
+  client  <- Resource.liftF(RabbitClient[IO](config, blocker, metricsCollector = Some(dropwizardCollector)))
+  channel <- client.createConnection.flatMap(client.createChannel)
+} yield (channel, client)
+
+val program = resources.use {
+  case (channel, client) =>
+    // Let's publish and consume and see the counters go up
+}
+```
+
+The app is going to have now the following metrics under `com.rabbitmq.client.jmx`:
+* Acknowledged messages
+* Channels count
+* Connections count
+* Consumed messages
+* Published messages
+* Rejected messages
+
+## Full Listing
+
+Let's create an application that publishes and consumes messages with exposed JMX metrics on top of the Cats Effect.
+
+```scala mdoc:silent
+import java.nio.charset.StandardCharsets.UTF_8
+
+import cats.data.{Kleisli, NonEmptyList}
+import cats.effect.{Blocker, ExitCode, IO, IOApp, Resource, Sync}
+import cats.implicits._
+import com.codahale.metrics.MetricRegistry
+import com.codahale.metrics.jmx.JmxReporter
+import com.rabbitmq.client.impl.StandardMetricsCollector
+import dev.profunktor.fs2rabbit.config.declaration.{DeclarationExchangeConfig, DeclarationQueueConfig}
+import dev.profunktor.fs2rabbit.config.{Fs2RabbitConfig, Fs2RabbitNodeConfig}
+import dev.profunktor.fs2rabbit.interpreter.RabbitClient
+import dev.profunktor.fs2rabbit.model.AckResult.Ack
+import dev.profunktor.fs2rabbit.model.ExchangeType.Topic
+import dev.profunktor.fs2rabbit.model._
+import dev.profunktor.fs2rabbit.examples.putStrLn
+import fs2._
+
+import scala.concurrent.duration._
+
+object DropwizardMetricsDemo extends IOApp {
+
+  private val config: Fs2RabbitConfig = Fs2RabbitConfig(
+    virtualHost = "/",
+    nodes = NonEmptyList.one(Fs2RabbitNodeConfig(host = "127.0.0.1", port = 5672)),
+    username = Some("guest"),
+    password = Some("guest"),
+    ssl = false,
+    connectionTimeout = 3,
+    requeueOnNack = false,
+    requeueOnReject = false,
+    internalQueueSize = Some(500),
+    automaticRecovery = true
+  )
+
+  private val queueName    = QueueName("testQ")
+  private val exchangeName = ExchangeName("testEX")
+  private val routingKey   = RoutingKey("testRK")
+
+  val simpleMessage = AmqpMessage("Hey!", AmqpProperties.empty)
+
+  implicit val stringMessageEncoder =
+    Kleisli[IO, AmqpMessage[String], AmqpMessage[Array[Byte]]] { s =>
+      s.copy(payload = s.payload.getBytes(UTF_8)).pure[IO]
+    }
+
+  override def run(args: List[String]): IO[ExitCode] = {
+    val registry            = new MetricRegistry
+    val dropwizardCollector = new StandardMetricsCollector(registry)
+
+    val resources = for {
+      blocker <- Blocker[IO]
+      _       <- JmxReporterResource.make[IO](registry)
+      client  <- Resource.liftF(RabbitClient[IO](config, blocker, metricsCollector = Some(dropwizardCollector)))
+      channel <- client.createConnection.flatMap(client.createChannel)
+    } yield (channel, client)
+
+    val program = resources.use {
+      case (channel, client) =>
+        implicit val c = channel
+
+        val setup =
+          for {
+            _                 <- client.declareQueue(DeclarationQueueConfig.default(queueName))
+            _                 <- client.declareExchange(DeclarationExchangeConfig.default(exchangeName, Topic))
+            _                 <- client.bindQueue(queueName, exchangeName, routingKey)
+            (acker, consumer) <- client.createAckerConsumer[String](queueName)
+            publisher         <- client.createPublisher[AmqpMessage[String]](exchangeName, routingKey)
+          } yield (consumer, acker, publisher)
+
+        Stream
+          .eval(setup)
+          .flatTap {
+            case (consumer, acker, publisher) =>
+              Stream(
+                Stream(simpleMessage).evalMap(publisher).repeat.metered(1.second),
+                consumer.through(logPipe).evalMap(acker)
+              ).parJoin(2)
+          }
+          .compile
+          .drain
+    }
+
+    program.as(ExitCode.Success)
+  }
+
+  def logPipe[F[_]: Sync]: Pipe[F, AmqpEnvelope[String], AckResult] =
+    _.evalMap { amqpMsg =>
+      putStrLn(s"Consumed: $amqpMsg").as(Ack(amqpMsg.deliveryTag))
+    }
+
+}
+
+object JmxReporterResource {
+  def make[F[_]: Sync](registry: MetricRegistry): Resource[F, JmxReporter] = {
+    val acquire = Sync[F].delay {
+      val reporter = JmxReporter.forRegistry(registry).inDomain("com.rabbitmq.client.jmx").build
+      reporter.start()
+      reporter
+    }
+
+    val close = (reporter: JmxReporter) => Sync[F].delay(reporter.close()).void
+
+    Resource.make(acquire)(close)
+  }
+}
+```

--- a/site/docs/examples/index.md
+++ b/site/docs/examples/index.md
@@ -10,9 +10,11 @@ position: 2
 The source code for some of the examples can be found [here](https://github.com/profunktor/fs2-rabbit/tree/master/examples/src/main/scala/dev.profunktor/fs2rabbit/examples).
 
 ### Simple
+
 - **[Single AutoAckConsumer](./sample-autoack.html)**: Example of a single `AutoAckConsumer`, a `Publisher` and `Json` data manipulation.
 - **[Single AckerConsumer](./sample-acker.html)**: Example of a single `AckerConsumer`, a `Publisher` and `Json` data  manipulation.
 - **[Multiple Consumers](./sample-mult-consumers.html)**: Two `Consumers` bound to queues with different `RoutingKey`, one `Publisher`.
+- **[Client Metrics](./client-metrics.html)**: Use RabbitMQ Java Client metrics collector to Dropwizard.
 
 ### Advanced
 


### PR DESCRIPTION
Motivation:

We would like to client statistics. Luckily, RabbitMQ Java Client includes implementations of Dropwizard and Micrometer metrics collectors. Let's expose them.

Modification:

- Add `metricsCollector` to the resource constructors.
- Add an example application that exposes metrics via JMX.
- Add an example into the microsite documentation.

Result:

- See JMX metrics via JConsole with Java Client 5.9.0 and Dropwizard 4.1.5

![image](https://user-images.githubusercontent.com/169803/90332494-4e107f00-dfb5-11ea-90d6-23e68991e431.png)
