### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import Dependencies._
 import microsites.ExtraMdFileConfig
 
 ThisBuild / name := """fs2-rabbit"""
-ThisBuild / crossScalaVersions := List("2.12.10", "2.13.1")
+ThisBuild / crossScalaVersions := List("2.12.12", "2.13.3")
 ThisBuild / organization := "dev.profunktor"
 ThisBuild / homepage := Some(url("https://fs2-rabbit.profunktor.dev/"))
 ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
@@ -20,7 +20,6 @@ import java.util.concurrent.Executors
 
 import cats.data.NonEmptyList
 import cats.effect._
-import cats.syntax.functor._
 import dev.profunktor.fs2rabbit.config.{Fs2RabbitConfig, Fs2RabbitNodeConfig}
 import dev.profunktor.fs2rabbit.interpreter.RabbitClient
 import dev.profunktor.fs2rabbit.resiliency.ResilientStream

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/ZIOAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/ZIOAutoAckConsumer.scala
@@ -46,7 +46,7 @@ object ZIOAutoAckConsumer extends CatsApp {
       .make(Task(Executors.newCachedThreadPool()))(es => Task(es.shutdown()))
       .map(Blocker.liftExecutorService)
 
-  override def run(args: List[String]): UIO[Int] =
+  override def run(args: List[String]): URIO[ZEnv, ExitCode] =
     blockerResource
       .use { blocker =>
         RabbitClient[Task](config, blocker).flatMap { client =>
@@ -54,7 +54,7 @@ object ZIOAutoAckConsumer extends CatsApp {
             .runF(new AutoAckConsumerDemo[Task](client).program)
         }
       }
-      .run
-      .map(_ => 0)
+      .orDie
+      .as(ExitCode.success)
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,14 +4,14 @@ object Dependencies {
 
   object Version {
     val cats       = "2.2.0"
-    val catsEffect = "2.1.2"
-    val fs2        = "2.3.0"
+    val catsEffect = "2.2.0"
+    val fs2        = "2.4.4"
     val circe      = "0.13.0"
     val amqpClient = "5.9.0"
     val logback    = "1.2.3"
-    val monix      = "3.1.0"
-    val zio        = "1.0.0-RC19-2"
-    val zioCats    = "2.0.0.0-RC14"
+    val monix      = "3.2.2"
+    val zio        = "1.0.1"
+    val zioCats    = "2.1.4.0"
     val scodec     = "1.0.0"
     val dropwizard = "4.1.12.1"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releas
 addSbtPlugin("com.geirsson"              % "sbt-ci-release" % "1.5.3")
 addSbtPlugin("de.heikoseeberger"         % "sbt-header"     % "5.6.0")
 addSbtPlugin("com.47deg"                 % "sbt-microsites" % "1.2.1")
-addSbtPlugin("org.scalameta"             % "sbt-mdoc"       % "2.1.4")
 addSbtPlugin("com.scalapenos"            % "sbt-prompt"     % "1.0.2")
 addSbtPlugin("com.lucidchart"            % "sbt-scalafmt"   % "1.16")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"   % "0.1.13")
+addSbtPlugin("com.timushev.sbt"          % "sbt-updates"    % "0.5.1")

--- a/site/docs/examples/sample-acker.md
+++ b/site/docs/examples/sample-acker.md
@@ -46,7 +46,7 @@ class Flow[F[_]: Concurrent, A](
   val flow: Stream[F, Unit] =
     Stream(
       Stream(simpleMessage).covary[F].evalMap(publisher),
-      Stream(classMessage).covary[F].through(jsonPipe).evalMap(publisher),
+      Stream(classMessage).through(jsonPipe).covary[F].evalMap(publisher),
       consumer.through(logger).evalMap(acker)
     ).parJoin(3)
 

--- a/site/docs/examples/sample-autoack.md
+++ b/site/docs/examples/sample-autoack.md
@@ -45,7 +45,7 @@ class AutoAckFlow[F[_]: Concurrent, A](
   val flow: Stream[F, Unit] =
     Stream(
       Stream(simpleMessage).covary[F] evalMap publisher,
-      Stream(classMessage).covary[F] through jsonPipe evalMap publisher,
+      Stream(classMessage).through(jsonPipe).covary[F] evalMap publisher,
       consumer.through(logger).evalMap(ack => Sync[F].delay(println(ack)))
     ).parJoin(3)
 

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/resiliency/ResilientStreamSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/resiliency/ResilientStreamSpec.scala
@@ -33,7 +33,7 @@ class ResilientStreamSpec extends BaseSpec {
 
   it should "run a stream until it's finished" in {
     val program = Stream(1, 2, 3).covary[IO].through(sink)
-    ResilientStream.run(program).as(emptyAssertion).unsafeToFuture
+    ResilientStream.run(program).as(emptyAssertion).unsafeToFuture()
   }
 
   it should "run a stream and recover in case of failure" in {
@@ -47,7 +47,7 @@ class ResilientStreamSpec extends BaseSpec {
         }
       }
 
-    Ref.of[IO, Int](2).flatMap(r => ResilientStream.run(p(r), 1.second)).as(emptyAssertion).unsafeToFuture
+    Ref.of[IO, Int](2).flatMap(r => ResilientStream.run(p(r), 1.second)).as(emptyAssertion).unsafeToFuture()
   }
 
 }


### PR DESCRIPTION
This PR resolves issues in the unmerged Steward's PRs.
Changes:
* update scalac to 2.12.12/2.13.3 and resolve new warnings
* update dependencies to the latest versions and resolve incompatibilities with fs2 and zio 
* remove sbt-mdoc plugin as it's already in sbt-microsites to resolve bin incompatibility
* fmt

closes #381 and closes #385 and closes #389 and closes #391 and closes #394