### PR TITLE
Allow to configure requestedHeartbeat

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
@@ -47,7 +47,7 @@ object ConnectionResource {
             factory.setPort(firstNode.port)
             factory.setVirtualHost(conf.virtualHost)
             factory.setConnectionTimeout(conf.connectionTimeout)
-            factory.setRequestedHeartbeat(conf.requestedHeartbeat.getOrElse(ConnectionFactory.DEFAULT_HEARTBEAT))
+            factory.setRequestedHeartbeat(conf.requestedHeartbeat)
             factory.setAutomaticRecoveryEnabled(conf.automaticRecovery)
             if (conf.ssl)
               sslCtx.fold(factory.useSslProtocol())(factory.useSslProtocol)

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
@@ -47,7 +47,7 @@ object ConnectionResource {
             factory.setPort(firstNode.port)
             factory.setVirtualHost(conf.virtualHost)
             factory.setConnectionTimeout(conf.connectionTimeout)
-            factory.setRequestedHeartbeat(conf.requestedHeartbeat)
+            factory.setRequestedHeartbeat(conf.requestedHeartbeat.getOrElse(60))
             factory.setAutomaticRecoveryEnabled(conf.automaticRecovery)
             if (conf.ssl)
               sslCtx.fold(factory.useSslProtocol())(factory.useSslProtocol)

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
@@ -47,7 +47,7 @@ object ConnectionResource {
             factory.setPort(firstNode.port)
             factory.setVirtualHost(conf.virtualHost)
             factory.setConnectionTimeout(conf.connectionTimeout)
-            factory.setRequestedHeartbeat(conf.requestedHeartbeat.getOrElse(60))
+            factory.setRequestedHeartbeat(conf.requestedHeartbeat.getOrElse(ConnectionFactory.DEFAULT_HEARTBEAT))
             factory.setAutomaticRecoveryEnabled(conf.automaticRecovery)
             if (conf.ssl)
               sslCtx.fold(factory.useSslProtocol())(factory.useSslProtocol)

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
@@ -47,6 +47,7 @@ object ConnectionResource {
             factory.setPort(firstNode.port)
             factory.setVirtualHost(conf.virtualHost)
             factory.setConnectionTimeout(conf.connectionTimeout)
+            factory.setRequestedHeartbeat(conf.requestedHeartbeat)
             factory.setAutomaticRecoveryEnabled(conf.automaticRecovery)
             if (conf.ssl)
               sslCtx.fold(factory.useSslProtocol())(factory.useSslProtocol)

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
@@ -33,6 +33,7 @@ case class Fs2RabbitConfig(
     requeueOnNack: Boolean,
     requeueOnReject: Boolean,
     internalQueueSize: Option[Int],
+    requestedHeartbeat: Option[Int],
     automaticRecovery: Boolean
 )
 
@@ -48,6 +49,7 @@ object Fs2RabbitConfig {
       requeueOnNack: Boolean,
       requeueOnReject: Boolean,
       internalQueueSize: Option[Int],
+      requestedHeartbeat: Int = 60,
       automaticRecovery: Boolean = true
   ): Fs2RabbitConfig = Fs2RabbitConfig(
     nodes = NonEmptyList.one(Fs2RabbitNodeConfig(host, port)),

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
@@ -17,6 +17,7 @@
 package dev.profunktor.fs2rabbit.config
 
 import cats.data.NonEmptyList
+import com.rabbitmq.client.ConnectionFactory
 
 case class Fs2RabbitNodeConfig(
     host: String,
@@ -33,7 +34,7 @@ case class Fs2RabbitConfig(
     requeueOnNack: Boolean,
     requeueOnReject: Boolean,
     internalQueueSize: Option[Int],
-    requestedHeartbeat: Option[Int],
+    requestedHeartbeat: Int,
     automaticRecovery: Boolean
 )
 
@@ -49,7 +50,7 @@ object Fs2RabbitConfig {
       requeueOnNack: Boolean,
       requeueOnReject: Boolean,
       internalQueueSize: Option[Int],
-      requestedHeartbeat: Option[Int] = None,
+      requestedHeartbeat: Int = ConnectionFactory.DEFAULT_HEARTBEAT,
       automaticRecovery: Boolean = true
   ): Fs2RabbitConfig = Fs2RabbitConfig(
     nodes = NonEmptyList.one(Fs2RabbitNodeConfig(host, port)),

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
@@ -49,7 +49,7 @@ object Fs2RabbitConfig {
       requeueOnNack: Boolean,
       requeueOnReject: Boolean,
       internalQueueSize: Option[Int],
-      requestedHeartbeat: Int = 60,
+      requestedHeartbeat: Option[Int] = Some(60),
       automaticRecovery: Boolean = true
   ): Fs2RabbitConfig = Fs2RabbitConfig(
     nodes = NonEmptyList.one(Fs2RabbitNodeConfig(host, port)),
@@ -61,6 +61,7 @@ object Fs2RabbitConfig {
     requeueOnNack = requeueOnNack,
     requeueOnReject = requeueOnReject,
     internalQueueSize = internalQueueSize,
+    requestedHeartbeat = requestedHeartbeat,
     automaticRecovery = automaticRecovery
   )
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
@@ -49,7 +49,7 @@ object Fs2RabbitConfig {
       requeueOnNack: Boolean,
       requeueOnReject: Boolean,
       internalQueueSize: Option[Int],
-      requestedHeartbeat: Option[Int] = Some(60),
+      requestedHeartbeat: Option[Int] = None,
       automaticRecovery: Boolean = true
   ): Fs2RabbitConfig = Fs2RabbitConfig(
     nodes = NonEmptyList.one(Fs2RabbitNodeConfig(host, port)),

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/DropwizardMetricsDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/DropwizardMetricsDemo.scala
@@ -46,6 +46,7 @@ object DropwizardMetricsDemo extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
+    requestedHeartbeat = Some(60),
     automaticRecovery = true
   )
 

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/DropwizardMetricsDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/DropwizardMetricsDemo.scala
@@ -46,7 +46,7 @@ object DropwizardMetricsDemo extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
-    requestedHeartbeat = Some(60),
+    requestedHeartbeat = 60,
     automaticRecovery = true
   )
 

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
@@ -36,6 +36,7 @@ object IOAckerConsumer extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
+    requestedHeartbeat = Some(60),
     automaticRecovery = true
   )
 

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
@@ -36,7 +36,7 @@ object IOAckerConsumer extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
-    requestedHeartbeat = Some(60),
+    requestedHeartbeat = 60,
     automaticRecovery = true
   )
 

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -42,6 +42,7 @@ object MonixAutoAckConsumer extends TaskApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
+    requestedHeartbeat = Some(60),
     automaticRecovery = true
   )
 

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -42,7 +42,7 @@ object MonixAutoAckConsumer extends TaskApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
-    requestedHeartbeat = Some(60),
+    requestedHeartbeat = 60,
     automaticRecovery = true
   )
 

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/RPCDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/RPCDemo.scala
@@ -47,6 +47,7 @@ object RPCDemo extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
+    requestedHeartbeat = Some(60),
     automaticRecovery = true
   )
 

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/RPCDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/RPCDemo.scala
@@ -47,7 +47,7 @@ object RPCDemo extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
-    requestedHeartbeat = Some(60),
+    requestedHeartbeat = 60,
     automaticRecovery = true
   )
 

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -27,9 +27,11 @@ val config = Fs2RabbitConfig(
   requeueOnNack = false,
   requeueOnReject = false,
   internalQueueSize = Some(500),
+  requestedHeartbeat = Some(30),
   automaticRecovery = true
 )
 ```
 
 The `internalQueueSize` indicates the size of the fs2's bounded queue used internally to communicate with the AMQP Java driver.
 The `automaticRecovery` indicates whether the AMQP Java driver should try to [recover broken connections](https://www.rabbitmq.com/api-guide.html#recovery).
+The `requestedHeartbeat` indicates [heartbeat timeout](https://www.rabbitmq.com/heartbeats.html#using-heartbeats-in-java). Should be non-zero and lower than 60.

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -27,7 +27,7 @@ val config = Fs2RabbitConfig(
   requeueOnNack = false,
   requeueOnReject = false,
   internalQueueSize = Some(500),
-  requestedHeartbeat = Some(30),
+  requestedHeartbeat = 30,
   automaticRecovery = true
 )
 ```

--- a/site/docs/examples/client-metrics.md
+++ b/site/docs/examples/client-metrics.md
@@ -109,7 +109,7 @@ object DropwizardMetricsDemo extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
-    requestedHeartbeat = Some(60),
+    requestedHeartbeat = 60,
     automaticRecovery = true
   )
 

--- a/site/docs/examples/client-metrics.md
+++ b/site/docs/examples/client-metrics.md
@@ -109,6 +109,7 @@ object DropwizardMetricsDemo extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
+    requestedHeartbeat = Some(60),
     automaticRecovery = true
   )
 

--- a/site/docs/examples/sample-acker.md
+++ b/site/docs/examples/sample-acker.md
@@ -113,6 +113,7 @@ object IOAckerConsumer extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
+    requestedHeartbeat = Some(60),
     automaticRecovery = true
   )
 

--- a/site/docs/examples/sample-acker.md
+++ b/site/docs/examples/sample-acker.md
@@ -113,7 +113,7 @@ object IOAckerConsumer extends IOApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
-    requestedHeartbeat = Some(60),
+    requestedHeartbeat = 60,
     automaticRecovery = true
   )
 

--- a/site/docs/examples/sample-autoack.md
+++ b/site/docs/examples/sample-autoack.md
@@ -103,7 +103,7 @@ object MonixAutoAckConsumer extends TaskApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
-    requestedHeartbeat = Some(60),
+    requestedHeartbeat = 60,
     automaticRecovery = true
   )
 

--- a/site/docs/examples/sample-autoack.md
+++ b/site/docs/examples/sample-autoack.md
@@ -103,6 +103,7 @@ object MonixAutoAckConsumer extends TaskApp {
     requeueOnNack = false,
     requeueOnReject = false,
     internalQueueSize = Some(500),
+    requestedHeartbeat = Some(60),
     automaticRecovery = true
   )
 

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/RabbitSuite.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/RabbitSuite.scala
@@ -38,7 +38,7 @@ class RabbitSuite extends BaseSpec with Fs2RabbitSpec {
       password = "guest".some,
       requeueOnNack = false,
       requeueOnReject = false,
-      requestedHeartbeat = 60.some,
+      requestedHeartbeat = 60,
       internalQueueSize = 500.some
     )
 

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/RabbitSuite.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/RabbitSuite.scala
@@ -38,6 +38,7 @@ class RabbitSuite extends BaseSpec with Fs2RabbitSpec {
       password = "guest".some,
       requeueOnNack = false,
       requeueOnReject = false,
+      requestedHeartbeat = 60.some,
       internalQueueSize = 500.some
     )
 


### PR DESCRIPTION
Motivation:

We would like to allow to configure [requestedHeartbeat](https://www.rabbitmq.com/heartbeats.html#using-heartbeats-in-java) parameter for users. 
Default value is 60 seconds. However, some systems are working optimally with values 10-20 sec. 


Modification:
- added optional parameter `requestedHeartbeat` to `Fs2RabbitConfig`
- default value is `60`
- updated doc

