### PR TITLE
ConnectionFactory should be created once for Connection

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
@@ -16,7 +16,6 @@
 
 package dev.profunktor.fs2rabbit.algebra
 
-import cats.data.NonEmptyList
 import cats.effect.{Resource, Sync}
 import cats.implicits._
 import com.rabbitmq.client.{Address, ConnectionFactory, DefaultSaslConfig, MetricsCollector, SaslConfig}
@@ -39,40 +38,36 @@ object ConnectionResource {
     Sync[F].delay {
       new Connection[Resource[F, *]] {
 
-        private[fs2rabbit] def mkConnectionFactory: F[(ConnectionFactory, NonEmptyList[Address])] =
-          Sync[F].delay {
-            val factory   = new ConnectionFactory()
-            val firstNode = conf.nodes.head
-            factory.setHost(firstNode.host)
-            factory.setPort(firstNode.port)
-            factory.setVirtualHost(conf.virtualHost)
-            factory.setConnectionTimeout(conf.connectionTimeout)
-            factory.setRequestedHeartbeat(conf.requestedHeartbeat)
-            factory.setAutomaticRecoveryEnabled(conf.automaticRecovery)
-            if (conf.ssl)
-              sslCtx.fold(factory.useSslProtocol())(factory.useSslProtocol)
-            factory.setSaslConfig(saslConf)
-            conf.username.foreach(factory.setUsername)
-            conf.password.foreach(factory.setPassword)
-            metricsCollector.foreach(factory.setMetricsCollector)
-            val addresses = conf.nodes.map(node => new Address(node.host, node.port))
-            (factory, addresses)
-          }
+        private[fs2rabbit] val connectionFactory = {
+          val factory   = new ConnectionFactory()
+          val firstNode = conf.nodes.head
+          factory.setHost(firstNode.host)
+          factory.setPort(firstNode.port)
+          factory.setVirtualHost(conf.virtualHost)
+          factory.setConnectionTimeout(conf.connectionTimeout)
+          factory.setRequestedHeartbeat(conf.requestedHeartbeat)
+          factory.setAutomaticRecoveryEnabled(conf.automaticRecovery)
+          if (conf.ssl) sslCtx.fold(factory.useSslProtocol())(factory.useSslProtocol)
+          factory.setSaslConfig(saslConf)
+          conf.username.foreach(factory.setUsername)
+          conf.password.foreach(factory.setPassword)
+          metricsCollector.foreach(factory.setMetricsCollector)
+          factory
+        }
+
+        private[fs2rabbit] val addresses = conf.nodes.map(node => new Address(node.host, node.port))
+
+        private[fs2rabbit] val acquireConnection: F[AMQPConnection] =
+          Sync[F]
+            .delay(connectionFactory.newConnection(addresses.toList.asJava))
+            .flatTap(c => Log[F].info(s"Acquired connection: $c"))
+            .map(RabbitConnection)
 
         private[fs2rabbit] def acquireChannel(connection: AMQPConnection): F[AMQPChannel] =
           Sync[F]
             .delay(connection.value.createChannel)
             .flatTap(c => Log[F].info(s"Acquired channel: $c"))
             .map(RabbitChannel)
-
-        private[fs2rabbit] val acquireConnection: F[AMQPConnection] =
-          mkConnectionFactory.flatMap {
-            case (factory, addresses) =>
-              Sync[F]
-                .delay(factory.newConnection(addresses.toList.asJava))
-                .flatTap(c => Log[F].info(s"Acquired connection: $c"))
-                .map(RabbitConnection)
-          }
 
         override def createConnection: Resource[F, AMQPConnection] =
           Resource.make(acquireConnection) {

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
@@ -35,58 +35,58 @@ object ConnectionResource {
       saslConf: SaslConfig = DefaultSaslConfig.PLAIN,
       metricsCollector: Option[MetricsCollector] = None
   ): F[Connection[Resource[F, *]]] =
-    Sync[F].delay {
-      new Connection[Resource[F, *]] {
-
-        private[fs2rabbit] val connectionFactory = {
-          val factory   = new ConnectionFactory()
-          val firstNode = conf.nodes.head
-          factory.setHost(firstNode.host)
-          factory.setPort(firstNode.port)
-          factory.setVirtualHost(conf.virtualHost)
-          factory.setConnectionTimeout(conf.connectionTimeout)
-          factory.setRequestedHeartbeat(conf.requestedHeartbeat)
-          factory.setAutomaticRecoveryEnabled(conf.automaticRecovery)
-          if (conf.ssl) sslCtx.fold(factory.useSslProtocol())(factory.useSslProtocol)
-          factory.setSaslConfig(saslConf)
-          conf.username.foreach(factory.setUsername)
-          conf.password.foreach(factory.setPassword)
-          metricsCollector.foreach(factory.setMetricsCollector)
-          factory
-        }
-
-        private[fs2rabbit] val addresses = conf.nodes.map(node => new Address(node.host, node.port))
-
-        private[fs2rabbit] val acquireConnection: F[AMQPConnection] =
-          Sync[F]
-            .delay(connectionFactory.newConnection(addresses.toList.asJava))
-            .flatTap(c => Log[F].info(s"Acquired connection: $c"))
-            .map(RabbitConnection)
-
-        private[fs2rabbit] def acquireChannel(connection: AMQPConnection): F[AMQPChannel] =
-          Sync[F]
-            .delay(connection.value.createChannel)
-            .flatTap(c => Log[F].info(s"Acquired channel: $c"))
-            .map(RabbitChannel)
-
-        override def createConnection: Resource[F, AMQPConnection] =
-          Resource.make(acquireConnection) {
-            case RabbitConnection(conn) =>
-              Log[F].info(s"Releasing connection: $conn previously acquired.") *>
-                Sync[F].delay {
-                  if (conn.isOpen) conn.close()
-                }
-          }
-
-        override def createChannel(connection: AMQPConnection): Resource[F, AMQPChannel] =
-          Resource.make(acquireChannel(connection)) {
-            case RabbitChannel(channel) =>
-              Sync[F].delay {
-                if (channel.isOpen) channel.close()
-              }
-          }
+    Sync[F]
+      .delay {
+        val factory   = new ConnectionFactory()
+        val firstNode = conf.nodes.head
+        factory.setHost(firstNode.host)
+        factory.setPort(firstNode.port)
+        factory.setVirtualHost(conf.virtualHost)
+        factory.setConnectionTimeout(conf.connectionTimeout)
+        factory.setRequestedHeartbeat(conf.requestedHeartbeat)
+        factory.setAutomaticRecoveryEnabled(conf.automaticRecovery)
+        if (conf.ssl) sslCtx.fold(factory.useSslProtocol())(factory.useSslProtocol)
+        factory.setSaslConfig(saslConf)
+        conf.username.foreach(factory.setUsername)
+        conf.password.foreach(factory.setPassword)
+        metricsCollector.foreach(factory.setMetricsCollector)
+        factory
       }
-    }
+      .map { connectionFactory =>
+        new Connection[Resource[F, *]] {
+
+          private[fs2rabbit] val addresses = conf.nodes.map(node => new Address(node.host, node.port))
+
+          private[fs2rabbit] val acquireConnection: F[AMQPConnection] =
+            Sync[F]
+              .delay(connectionFactory.newConnection(addresses.toList.asJava))
+              .flatTap(c => Log[F].info(s"Acquired connection: $c"))
+              .map(RabbitConnection)
+
+          private[fs2rabbit] def acquireChannel(connection: AMQPConnection): F[AMQPChannel] =
+            Sync[F]
+              .delay(connection.value.createChannel)
+              .flatTap(c => Log[F].info(s"Acquired channel: $c"))
+              .map(RabbitChannel)
+
+          override def createConnection: Resource[F, AMQPConnection] =
+            Resource.make(acquireConnection) {
+              case RabbitConnection(conn) =>
+                Log[F].info(s"Releasing connection: $conn previously acquired.") *>
+                  Sync[F].delay {
+                    if (conn.isOpen) conn.close()
+                  }
+            }
+
+          override def createChannel(connection: AMQPConnection): Resource[F, AMQPChannel] =
+            Resource.make(acquireChannel(connection)) {
+              case RabbitChannel(channel) =>
+                Sync[F].delay {
+                  if (channel.isOpen) channel.close()
+                }
+            }
+        }
+      }
 }
 
 trait Connection[F[_]] {


### PR DESCRIPTION
I added `println("\n\nI'm creating a new conectionFactory\n\n")` to dev/profunktor/fs2rabbit/algebra/Connection.scala:44,
run the example with `> examples/ test:runMain dev.profunktor.fs2rabbit.examples.FactoryTest`

```
[info] running dev.profunktor.fs2rabbit.examples.FactoryTest 


I'm creating a new conectionFactory


17:28:46.434 [ioapp-compute-0] INFO  d.profunktor.fs2rabbit.effects.Log$ - Acquired connection: amqp://guest@127.0.0.1:5672/


I'm creating a new conectionFactory


17:28:46.444 [ioapp-compute-0] INFO  d.profunktor.fs2rabbit.effects.Log$ - Acquired connection: amqp://guest@127.0.0.1:5672/
```



```
object FactoryTest extends IOApp {

  override def run(args: List[String]): IO[ExitCode] = {
    val config = Fs2RabbitConfig(
      host = "127.0.0.1",
      port = 5672,
      virtualHost = "/",
      username = Some("guest"),
      password = Some("guest"),
      ssl = false,
      connectionTimeout = 3,
      requeueOnNack = false,
      requeueOnReject = false,
      internalQueueSize = Some(500)
    )

    val blockerResource =
      Resource
        .make(IO(Executors.newCachedThreadPool()))(es => IO(es.shutdown()))
        .map(Blocker.liftExecutorService)

    val resource =
      for {
        blocker <- blockerResource
        client  <- Resource.liftF(RabbitClient[IO](config, blocker))
        _       <- client.createConnection
        _       <- client.createConnection
      } yield {}

    resource.use(_ => IO.pure(ExitCode.Success))
  }
}
```

I think that connectionFactory should be created once for ConnectionResource.make, this PR does this.