### PR TITLE
Don't wrap Binding.unbindQueue call in Sync.delay

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Binding.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Binding.scala
@@ -68,15 +68,13 @@ object Binding {
                                queueName: QueueName,
                                exchangeName: ExchangeName,
                                routingKey: RoutingKey): F[Unit] =
-        Sync[F].delay {
-          unbindQueue(
-            channel,
-            queueName,
-            exchangeName,
-            routingKey,
-            QueueUnbindArgs(Map.empty)
-          )
-        }.void
+        unbindQueue(
+          channel,
+          queueName,
+          exchangeName,
+          routingKey,
+          QueueUnbindArgs(Map.empty)
+        )
 
       override def unbindQueue(channel: AMQPChannel,
                                queueName: QueueName,


### PR DESCRIPTION
The call from `unbindQueue` doesn't need wrapping in `Sync.delay` because it's already inside `blocker.delay`