### PR TITLE
Use `ConsumerArgs` where possible instead of passing 4 parameters

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Consuming.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Consuming.scala
@@ -26,6 +26,7 @@ object ConsumingStream {
 }
 
 trait Consuming[F[_], R[_]] {
+  @deprecated(message = "Use createConsumer with ConsumerArgs", since = "3.0.2")
   def createConsumer[A](
       queueName: QueueName,
       channel: AMQPChannel,
@@ -35,5 +36,25 @@ trait Consuming[F[_], R[_]] {
       exclusive: Boolean = false,
       consumerTag: ConsumerTag = ConsumerTag(""),
       args: Arguments = Map.empty
+  )(implicit decoder: EnvelopeDecoder[F, A]): F[R[AmqpEnvelope[A]]] =
+    createConsumer(
+      queueName = queueName,
+      channel = channel,
+      basicQos = basicQos,
+      autoAck = autoAck,
+      consumerArgs = ConsumerArgs(
+        noLocal = noLocal,
+        exclusive = exclusive,
+        consumerTag = consumerTag,
+        args = args
+      )
+    )
+
+  def createConsumer[A](
+      queueName: QueueName,
+      channel: AMQPChannel,
+      basicQos: BasicQos,
+      autoAck: Boolean,
+      consumerArgs: ConsumerArgs
   )(implicit decoder: EnvelopeDecoder[F, A]): F[R[AmqpEnvelope[A]]]
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -22,10 +22,10 @@ import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.Date
 
+import cats._
 import cats.data._
 import cats.implicits._
 import cats.kernel.CommutativeSemigroup
-import cats._
 import com.rabbitmq.client.{AMQP, Channel, Connection, LongString}
 import dev.profunktor.fs2rabbit.arguments.Arguments
 import dev.profunktor.fs2rabbit.effects.{EnvelopeDecoder, MessageEncoder}
@@ -72,6 +72,15 @@ object model {
   }
 
   case class ConsumerArgs(consumerTag: ConsumerTag, noLocal: Boolean, exclusive: Boolean, args: Arguments)
+  object ConsumerArgs {
+    val default: ConsumerArgs =
+      ConsumerArgs(
+        noLocal = false,
+        exclusive = false,
+        consumerTag = ConsumerTag(""),
+        args = Map.empty
+      )
+  }
   case class BasicQos(prefetchSize: Int, prefetchCount: Int, global: Boolean = false)
 
   sealed trait ExchangeType extends Product with Serializable

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
@@ -19,7 +19,6 @@ package dev.profunktor.fs2rabbit.program
 import cats.Applicative
 import cats.effect.{Blocker, ContextShift, Effect, Sync}
 import dev.profunktor.fs2rabbit.algebra.{AMQPInternals, Acking, Consume}
-import dev.profunktor.fs2rabbit.arguments.Arguments
 import dev.profunktor.fs2rabbit.config.Fs2RabbitConfig
 import dev.profunktor.fs2rabbit.model.AckResult.{Ack, NAck, Reject}
 import dev.profunktor.fs2rabbit.model._
@@ -59,11 +58,8 @@ case class WrapperAckingProgram[F[_]: Effect] private (
   override def basicConsume[A](channel: AMQPChannel,
                                queueName: QueueName,
                                autoAck: Boolean,
-                               consumerTag: ConsumerTag,
-                               noLocal: Boolean,
-                               exclusive: Boolean,
-                               args: Arguments)(internals: AMQPInternals[F]): F[ConsumerTag] =
-    consume.basicConsume(channel, queueName, autoAck, consumerTag, noLocal, exclusive, args)(internals)
+                               consumerArgs: ConsumerArgs)(internals: AMQPInternals[F]): F[ConsumerTag] =
+    consume.basicConsume(channel, queueName, autoAck, consumerArgs)(internals)
 
   override def basicCancel(channel: AMQPChannel, consumerTag: ConsumerTag): F[Unit] =
     consume.basicCancel(channel, consumerTag)


### PR DESCRIPTION
It looks like we're passing 4 parameters around in multiple places, but we could simply use `ConsumerArgs`.

- Use `ConsumerArgs` instead of passing 4 parameters
- Move default method parameters to `ConsumerArgs.default`

This is a non-breaking change as I've kept the existing methods, marked them as deprecated, and they call the new methods I've defined.
