### PR TITLE
Add mima support for backwards compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,8 @@ val commonSettings = List(
     )
   },
   resolvers += "Apache public" at "https://repository.apache.org/content/groups/public/",
-  scalafmtOnCompile := true
+  scalafmtOnCompile := true,
+  mimaPreviousArtifacts := Set(organization.value %% moduleName.value % "3.0.1"),
 )
 
 def CoreDependencies(scalaVersionStr: String): List[ModuleID] =
@@ -95,6 +96,7 @@ lazy val noPublish = List(
 
 lazy val `fs2-rabbit-root` = project
   .in(file("."))
+  .disablePlugins(MimaPlugin)
   .aggregate(`fs2-rabbit`, `fs2-rabbit-circe`, tests, examples, microsite, `fs2-rabbit-testkit`)
   .settings(noPublish)
 
@@ -118,6 +120,7 @@ lazy val tests = project
   .settings(commonSettings: _*)
   .settings(noPublish)
   .enablePlugins(AutomateHeaderPlugin)
+  .disablePlugins(MimaPlugin)
   .settings(libraryDependencies ++= TestsDependencies(scalaVersion.value))
   .settings(parallelExecution in Test := false)
   .dependsOn(`fs2-rabbit`, `fs2-rabbit-testkit`)
@@ -128,6 +131,7 @@ lazy val examples = project
   .settings(libraryDependencies ++= ExamplesDependencies(scalaVersion.value))
   .settings(noPublish)
   .enablePlugins(AutomateHeaderPlugin)
+  .disablePlugins(MimaPlugin)
   .dependsOn(`fs2-rabbit`, `fs2-rabbit-circe`)
 
 lazy val `fs2-rabbit-testkit` = project
@@ -140,6 +144,7 @@ lazy val `fs2-rabbit-testkit` = project
 lazy val microsite = project
   .in(file("site"))
   .enablePlugins(MicrositesPlugin)
+  .disablePlugins(MimaPlugin)
   .settings(commonSettings: _*)
   .settings(noPublish)
   .settings(
@@ -178,4 +183,4 @@ lazy val microsite = project
   .dependsOn(`fs2-rabbit`, `fs2-rabbit-circe`, `examples`)
 
 // CI build
-addCommandAlias("buildFs2Rabbit", ";clean;+test;mdoc")
+addCommandAlias("buildFs2Rabbit", ";clean;+mimaReportBinaryIssues;+test;mdoc")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,12 @@
 resolvers += Classpaths.sbtPluginReleases
 resolvers += "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("com.geirsson"              % "sbt-ci-release" % "1.5.5")
-addSbtPlugin("de.heikoseeberger"         % "sbt-header"     % "5.6.0")
-addSbtPlugin("com.47deg"                 % "sbt-microsites" % "1.2.1")
-addSbtPlugin("org.scalameta"             % "sbt-mdoc"       % "2.2.14")
-addSbtPlugin("com.scalapenos"            % "sbt-prompt"     % "1.0.2")
-addSbtPlugin("com.lucidchart"            % "sbt-scalafmt"   % "1.16")
-addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"   % "0.1.16")
-addSbtPlugin("com.timushev.sbt"          % "sbt-updates"    % "0.5.1")
+addSbtPlugin("com.geirsson"              % "sbt-ci-release"  % "1.5.5")
+addSbtPlugin("de.heikoseeberger"         % "sbt-header"      % "5.6.0")
+addSbtPlugin("com.47deg"                 % "sbt-microsites"  % "1.2.1")
+addSbtPlugin("org.scalameta"             % "sbt-mdoc"        % "2.2.14")
+addSbtPlugin("com.scalapenos"            % "sbt-prompt"      % "1.0.2")
+addSbtPlugin("com.lucidchart"            % "sbt-scalafmt"    % "1.16")
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"    % "0.1.16")
+addSbtPlugin("com.timushev.sbt"          % "sbt-updates"     % "0.5.1")
+addSbtPlugin("com.typesafe"              % "sbt-mima-plugin" % "0.8.1")


### PR DESCRIPTION
Would prefer to use https://github.com/ChristopherDavenport/sbt-mima-version-check as it automates the version-checking against valid version ranges which the plugin discovers, rather than hard-coding things as I've done in this PR. However at the moment we can't use that plugin exactly the way that we want, but I've put in a PR to try to allow some more configuration which will suit fs2-rabbit better: https://github.com/ChristopherDavenport/sbt-mima-version-check/pull/70