### PR TITLE
add configurable thread factory to rabbit client connection

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
@@ -16,6 +16,8 @@
 
 package dev.profunktor.fs2rabbit.interpreter
 
+import java.util.concurrent.ThreadFactory
+
 import cats.effect._
 import cats.effect.std.Dispatcher
 import cats.implicits._
@@ -41,7 +43,8 @@ object RabbitClient {
       // Unlike SSLContext, SaslConfig is not optional because it is always set
       // by the underlying Java library, even if the user doesn't set it.
       saslConfig: SaslConfig = DefaultSaslConfig.PLAIN,
-      metricsCollector: Option[MetricsCollector] = None
+      metricsCollector: Option[MetricsCollector] = None,
+      threadFactory: Option[F[ThreadFactory]] = None
   ): F[RabbitClient[F]] = {
     val internalQ         = new LiveInternalQueue[F](config.internalQueueSize.getOrElse(500))
     val connection        = ConnectionResource.make(config, sslContext, saslConfig, metricsCollector)

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
@@ -47,7 +47,7 @@ object RabbitClient {
       threadFactory: Option[F[ThreadFactory]] = None
   ): F[RabbitClient[F]] = {
     val internalQ         = new LiveInternalQueue[F](config.internalQueueSize.getOrElse(500))
-    val connection        = ConnectionResource.make(config, sslContext, saslConfig, metricsCollector)
+    val connection        = ConnectionResource.make(config, sslContext, saslConfig, metricsCollector, threadFactory)
     val consumingProgram  = AckConsumingProgram.make[F](config, internalQ, dispatcher)
     val publishingProgram = PublishingProgram.make[F](dispatcher)
 


### PR DESCRIPTION
resolves #403  

adding this to the branch for the next major (4.0.0) so don't need to worry about compatibility

