### PR TITLE
Reducing `RabbitClient`s dependencies

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Cancel.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Cancel.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2020 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.fs2rabbit.algebra
+
+import dev.profunktor.fs2rabbit.model.{AMQPChannel, ConsumerTag}
+
+trait Cancel[F[_]] {
+  def basicCancel(channel: AMQPChannel, consumerTag: ConsumerTag): F[Unit]
+}

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Cancel.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Cancel.scala
@@ -18,6 +18,8 @@ package dev.profunktor.fs2rabbit.algebra
 
 import dev.profunktor.fs2rabbit.model.{AMQPChannel, ConsumerTag}
 
+/** A trait that represents the ability to cancel a consumer
+  */
 trait Cancel[F[_]] {
   def basicCancel(channel: AMQPChannel, consumerTag: ConsumerTag): F[Unit]
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Consume.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Consume.scala
@@ -161,7 +161,7 @@ object Consume {
     }
 }
 
-trait Consume[F[_]] {
+trait Consume[F[_]] extends Cancel[F] {
   def basicAck(channel: AMQPChannel, tag: DeliveryTag, multiple: Boolean): F[Unit]
   def basicNack(channel: AMQPChannel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit]
   def basicReject(channel: AMQPChannel, tag: DeliveryTag, requeue: Boolean): F[Unit]
@@ -175,5 +175,4 @@ trait Consume[F[_]] {
       exclusive: Boolean,
       args: Arguments
   )(internals: AMQPInternals[F]): F[ConsumerTag]
-  def basicCancel(channel: AMQPChannel, consumerTag: ConsumerTag): F[Unit]
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/arguments.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/arguments.scala
@@ -16,7 +16,7 @@
 
 package dev.profunktor.fs2rabbit
 
-import scala.annotation.{implicitNotFound, nowarn}
+import scala.annotation.implicitNotFound
 import dev.profunktor.fs2rabbit.javaConversion._
 
 object arguments {

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/arguments.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/arguments.scala
@@ -16,7 +16,7 @@
 
 package dev.profunktor.fs2rabbit
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{implicitNotFound, nowarn}
 import dev.profunktor.fs2rabbit.javaConversion._
 
 object arguments {
@@ -49,7 +49,7 @@ object arguments {
   }
 
   object SafeArgument {
-    private[fs2rabbit] def apply[A](implicit ev: SafeArgument[A]): SafeArgument[A] = ev
+    private[fs2rabbit] def apply[A](implicit ev: SafeArgument[A]): SafeArgument[A]      = ev
     private[fs2rabbit] def instance[A, J >: Null <: AnyRef](f: A => J): SafeArgument[A] =
       new SafeArgument[A] {
         type JavaType = J

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
@@ -26,9 +26,8 @@ import dev.profunktor.fs2rabbit.model.AckResult.{Ack, NAck, Reject}
 import dev.profunktor.fs2rabbit.model._
 
 object AckingProgram {
-  def make[F[_]: Sync](config: Fs2RabbitConfig, dispatcher: Dispatcher[F]): F[AckingProgram[F]] = Sync[F].delay {
+  def make[F[_]: Sync](config: Fs2RabbitConfig, dispatcher: Dispatcher[F]): AckingProgram[F] =
     WrapperAckingProgram(config, Consume.make(dispatcher))
-  }
 }
 
 trait AckingProgram[F[_]] extends Acking[F] with Consume[F]
@@ -57,13 +56,15 @@ case class WrapperAckingProgram[F[_]: Sync] private (
   override def basicQos(channel: AMQPChannel, basicQos: BasicQos): F[Unit] =
     consume.basicQos(channel, basicQos)
 
-  override def basicConsume[A](channel: AMQPChannel,
-                               queueName: QueueName,
-                               autoAck: Boolean,
-                               consumerTag: ConsumerTag,
-                               noLocal: Boolean,
-                               exclusive: Boolean,
-                               args: Arguments)(internals: AMQPInternals[F]): F[ConsumerTag] =
+  override def basicConsume[A](
+      channel: AMQPChannel,
+      queueName: QueueName,
+      autoAck: Boolean,
+      consumerTag: ConsumerTag,
+      noLocal: Boolean,
+      exclusive: Boolean,
+      args: Arguments
+  )(internals: AMQPInternals[F]): F[ConsumerTag] =
     consume.basicConsume(channel, queueName, autoAck, consumerTag, noLocal, exclusive, args)(internals)
 
   override def basicCancel(channel: AMQPChannel, consumerTag: ConsumerTag): F[Unit] =

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/ConsumingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/ConsumingProgram.scala
@@ -17,7 +17,6 @@
 package dev.profunktor.fs2rabbit.program
 
 import cats.effect.Sync
-import cats.effect.std.Dispatcher
 import cats.implicits._
 import dev.profunktor.fs2rabbit.algebra.ConsumingStream._
 import dev.profunktor.fs2rabbit.algebra.{AMQPInternals, Consume, InternalQueue}
@@ -27,10 +26,8 @@ import dev.profunktor.fs2rabbit.model._
 import fs2.Stream
 
 object ConsumingProgram {
-  def make[F[_]: Sync](internalQueue: InternalQueue[F], dispatcher: Dispatcher[F]): F[ConsumingProgram[F]] =
-    Sync[F].delay {
-      WrapperConsumingProgram(internalQueue, Consume.make(dispatcher))
-    }
+  def make[F[_]: Sync](internalQueue: InternalQueue[F], consume: Consume[F]): ConsumingProgram[F] =
+    WrapperConsumingProgram(internalQueue, consume)
 }
 
 trait ConsumingProgram[F[_]] extends ConsumingStream[F] with Consume[F]


### PR DESCRIPTION
Some consolidation of the classes wrapped by `RabbitClient`

- some algebras creations were unnecessarily wrapped in `Sync[F].delay`
- RabbitClient required a `Publish` and a `Publishing`, but `PublishingProgram` extends both of those
- RabbitClient required a `Consuming` and a `Consume`, and `AckConsumingProgram` filled the requirement of both except for one method, `basicCancel`, so I pulled that into its own trait `Cancel`, and had `AckConsumingProgram` extend `Cancel`, so it can replace the two consume dependencies