### PR TITLE
create acker consumer with configurable ack-multiple flag

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import microsites.ExtraMdFileConfig
 
 ThisBuild / name := """fs2-rabbit"""
 ThisBuild / scalaVersion := "2.13.5"
-ThisBuild / crossScalaVersions := List("2.12.12", "2.13.5")
+ThisBuild / crossScalaVersions := List("2.12.13", "2.13.5")
 ThisBuild / organization := "dev.profunktor"
 ThisBuild / homepage := Some(url("https://fs2-rabbit.profunktor.dev/"))
 ThisBuild / licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AckConsuming.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AckConsuming.scala
@@ -29,7 +29,8 @@ trait AckConsuming[F[_], R[_]] {
       channel: AMQPChannel,
       queueName: QueueName,
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
-      consumerArgs: Option[ConsumerArgs] = None
+      consumerArgs: Option[ConsumerArgs] = None,
+      ackMultiple: AckMultiple = AckMultiple(false)
   )(implicit decoder: EnvelopeDecoder[F, A]): F[(AckResult => F[Unit], R[AmqpEnvelope[A]])]
 
   def createAutoAckConsumer[A](
@@ -38,4 +39,11 @@ trait AckConsuming[F[_], R[_]] {
       basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
       consumerArgs: Option[ConsumerArgs] = None
   )(implicit decoder: EnvelopeDecoder[F, A]): F[R[AmqpEnvelope[A]]]
+
+  def createAckerConsumerWithMultipleFlag[A](
+      channel: AMQPChannel,
+      queueName: QueueName,
+      basicQos: BasicQos = BasicQos(prefetchSize = 0, prefetchCount = 1),
+      consumerArgs: Option[ConsumerArgs] = None
+  )(implicit decoder: EnvelopeDecoder[F, A]): F[((AckResult, AckMultiple) => F[Unit], R[AmqpEnvelope[A]])]
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Acking.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Acking.scala
@@ -16,8 +16,9 @@
 
 package dev.profunktor.fs2rabbit.algebra
 
-import dev.profunktor.fs2rabbit.model.{AMQPChannel, AckResult}
+import dev.profunktor.fs2rabbit.model.{AMQPChannel, AckMultiple, AckResult}
 
 trait Acking[F[_]] {
-  def createAcker(channel: AMQPChannel): F[AckResult => F[Unit]]
+  def createAcker(channel: AMQPChannel, ackMultiple: AckMultiple): F[AckResult => F[Unit]]
+  def createAckerWithMultipleFlag(channel: AMQPChannel): F[(AckResult, AckMultiple) => F[Unit]]
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -49,25 +49,25 @@ object model {
   case class RabbitConnection(value: Connection) extends AMQPConnection
 
   case class ExchangeName(value: String) extends AnyVal
-  object ExchangeName                    extends (String => ExchangeName) {
+  object ExchangeName extends (String => ExchangeName) {
     implicit val exchangeNameOrder: Order[ExchangeName] = Order.by(_.value)
   }
-  case class QueueName(value: String)    extends AnyVal
-  object QueueName                       extends (String => QueueName)    {
+  case class QueueName(value: String) extends AnyVal
+  object QueueName extends (String => QueueName) {
     implicit val queueNameOrder: Order[QueueName] = Order.by(_.value)
   }
-  case class RoutingKey(value: String)   extends AnyVal
-  object RoutingKey                      extends (String => RoutingKey)   {
+  case class RoutingKey(value: String) extends AnyVal
+  object RoutingKey extends (String => RoutingKey) {
     implicit val routingKeyOrder: Order[RoutingKey] = Order.by(_.value)
   }
-  case class DeliveryTag(value: Long)    extends AnyVal
-  object DeliveryTag                     extends (Long => DeliveryTag)    {
-    implicit val deliveryTagOrder: Order[DeliveryTag]                               = Order.by(_.value)
+  case class DeliveryTag(value: Long) extends AnyVal
+  object DeliveryTag extends (Long => DeliveryTag) {
+    implicit val deliveryTagOrder: Order[DeliveryTag] = Order.by(_.value)
     implicit val deliveryTagCommutativeSemigroup: CommutativeSemigroup[DeliveryTag] =
       CommutativeSemigroup.instance(_ max _)
   }
-  case class ConsumerTag(value: String)  extends AnyVal
-  object ConsumerTag                     extends (String => ConsumerTag)  {
+  case class ConsumerTag(value: String) extends AnyVal
+  object ConsumerTag extends (String => ConsumerTag) {
     implicit val consumerTagOrder: Order[ConsumerTag] = Order.by(_.value)
   }
 
@@ -177,7 +177,7 @@ object model {
       def from(instant: Instant): TimestampVal =
         new TimestampVal(instant.truncatedTo(ChronoUnit.SECONDS)) {}
 
-      def from(date: Date): TimestampVal       = from(date.toInstant)
+      def from(date: Date): TimestampVal = from(date.toInstant)
 
       implicit val timestampOrder: Order[TimestampVal] =
         Order.by[TimestampVal, Instant](_.instantWithOneSecondAccuracy)(instantOrderWithSecondPrecision)
@@ -202,11 +202,9 @@ object model {
         * not met, then we get back None.
         */
       def from(bigDecimal: BigDecimal): Option[DecimalVal] =
-        if (
-          getFullBitLengthOfUnscaled(bigDecimal) > MaxUnscaledBits ||
-          bigDecimal.scale > MaxScaleValue ||
-          bigDecimal.scale < 0
-        ) {
+        if (getFullBitLengthOfUnscaled(bigDecimal) > MaxUnscaledBits ||
+            bigDecimal.scale > MaxScaleValue ||
+            bigDecimal.scale < 0) {
           None
         } else {
           Some(new DecimalVal(bigDecimal) {})
@@ -218,7 +216,7 @@ object model {
         *
         * Almost always you should be using [[from]].
         */
-      def unsafeFrom(bigDecimal: BigDecimal): DecimalVal                  =
+      def unsafeFrom(bigDecimal: BigDecimal): DecimalVal =
         new DecimalVal(bigDecimal) {}
 
       private def getFullBitLengthOfUnscaled(bigDecimal: BigDecimal): Int =
@@ -229,74 +227,74 @@ object model {
       implicit val decimalValOrder: Order[DecimalVal] = Order.by(_.sizeLimitedBigDecimal)
     }
 
-    final case class TableVal(value: Map[ShortString, AmqpFieldValue]) extends AmqpFieldValue                                 {
+    final case class TableVal(value: Map[ShortString, AmqpFieldValue]) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.util.Map[String, AnyRef] =
         value.map { case (key, v) => key.str -> v.toValueWriterCompatibleJava }.asJava
     }
-    object TableVal                                                    extends (Map[ShortString, AmqpFieldValue] => TableVal) {
+    object TableVal extends (Map[ShortString, AmqpFieldValue] => TableVal) {
       implicit val tableValEq: Eq[TableVal] = Eq.by(_.value)
     }
-    final case class ByteVal(value: Byte)                              extends AmqpFieldValue                                 {
+    final case class ByteVal(value: Byte) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.lang.Byte = Byte.box(value)
     }
-    object ByteVal                                                     extends (Byte => ByteVal)                              {
+    object ByteVal extends (Byte => ByteVal) {
       implicit val byteValOrder: Order[ByteVal] = Order.by(_.value)
     }
-    final case class DoubleVal(value: Double)                          extends AmqpFieldValue                                 {
+    final case class DoubleVal(value: Double) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.lang.Double = Double.box(value)
     }
-    object DoubleVal                                                   extends (Double => DoubleVal)                          {
+    object DoubleVal extends (Double => DoubleVal) {
       implicit val doubleValOrder: Order[DoubleVal] = Order.by(_.value)
     }
-    final case class FloatVal(value: Float)                            extends AmqpFieldValue                                 {
+    final case class FloatVal(value: Float) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.lang.Float = Float.box(value)
     }
-    object FloatVal                                                    extends (Float => FloatVal)                            {
+    object FloatVal extends (Float => FloatVal) {
       implicit val floatValOrder: Order[FloatVal] = Order.by(_.value)
     }
-    final case class ShortVal(value: Short)                            extends AmqpFieldValue                                 {
+    final case class ShortVal(value: Short) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.lang.Short = Short.box(value)
     }
-    object ShortVal                                                    extends (Short => ShortVal)                            {
+    object ShortVal extends (Short => ShortVal) {
       implicit val shortValOrder: Order[ShortVal] = Order.by(_.value)
     }
-    final case class ByteArrayVal(value: ByteVector)                   extends AmqpFieldValue                                 {
+    final case class ByteArrayVal(value: ByteVector) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: Array[Byte] = value.toArray
     }
-    object ByteArrayVal                                                extends (ByteVector => ByteArrayVal)                   {
+    object ByteArrayVal extends (ByteVector => ByteArrayVal) {
       implicit val byteArrayValEq: Eq[ByteArrayVal] = Eq.by(_.value)
     }
-    final case class BooleanVal(value: Boolean)                        extends AmqpFieldValue                                 {
+    final case class BooleanVal(value: Boolean) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.lang.Boolean = Boolean.box(value)
     }
-    object BooleanVal                                                  extends (Boolean => BooleanVal)                        {
+    object BooleanVal extends (Boolean => BooleanVal) {
       implicit val booleanValOrder: Order[BooleanVal] = Order.by(_.value)
     }
-    final case class IntVal(value: Int)                                extends AmqpFieldValue                                 {
+    final case class IntVal(value: Int) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.lang.Integer = Int.box(value)
     }
-    object IntVal                                                      extends (Int => IntVal)                                {
+    object IntVal extends (Int => IntVal) {
       implicit val intValOrder: Order[IntVal] = Order.by(_.value)
     }
-    final case class LongVal(value: Long)                              extends AmqpFieldValue                                 {
+    final case class LongVal(value: Long) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.lang.Long = Long.box(value)
     }
-    object LongVal                                                     extends (Long => LongVal)                              {
+    object LongVal extends (Long => LongVal) {
       implicit val longValOrder: Order[LongVal] = Order.by(_.value)
     }
-    final case class StringVal(value: String)                          extends AmqpFieldValue                                 {
+    final case class StringVal(value: String) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: String = value
     }
-    object StringVal                                                   extends (String => StringVal)                          {
+    object StringVal extends (String => StringVal) {
       implicit val stringValOrder: Order[StringVal] = Order.by(_.value)
     }
-    final case class ArrayVal(value: Vector[AmqpFieldValue])           extends AmqpFieldValue                                 {
+    final case class ArrayVal(value: Vector[AmqpFieldValue]) extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: java.util.List[AnyRef] = value.map(_.toValueWriterCompatibleJava).asJava
     }
-    object ArrayVal                                                    extends (Vector[AmqpFieldValue] => ArrayVal)           {
+    object ArrayVal extends (Vector[AmqpFieldValue] => ArrayVal) {
       implicit val arrayValEq: Eq[ArrayVal] = Eq.by(_.value)
     }
-    case object NullVal                                                extends AmqpFieldValue                                 {
+    case object NullVal extends AmqpFieldValue {
       override def toValueWriterCompatibleJava: Null = null
 
       implicit val nullValOrder: Order[NullVal.type] = Order.allEqual
@@ -316,9 +314,9 @@ object model {
       // representation size must have already occurred because ValueReader will
       // only read a maximum of 4 bytes before bailing out (similarly it will
       // read no more than the first 8 bits to determine scale).
-      case bd: java.math.BigDecimal                               => DecimalVal.unsafeFrom(bd)
-      case ts: java.time.Instant                                  => TimestampVal.from(ts)
-      case d: java.util.Date                                      => TimestampVal.from(d)
+      case bd: java.math.BigDecimal => DecimalVal.unsafeFrom(bd)
+      case ts: java.time.Instant    => TimestampVal.from(ts)
+      case d: java.util.Date        => TimestampVal.from(d)
       // Looking at com.rabbitmq.client.impl.ValueReader.readFieldValue reveals
       // that java.util.Maps must always be created by
       // com.rabbitmq.client.impl.ValueReader.readTable, whose Maps must always
@@ -331,16 +329,16 @@ object model {
         // one byte to determine how large of a byte array to allocate for the
         // string which means the length cannot possibly exceed 255.
         TableVal(t.asScala.toMap.map { case (key, v) => ShortString.unsafeFrom(key) -> unsafeFrom(v) })
-      case byte: java.lang.Byte                                   => ByteVal(byte)
-      case double: java.lang.Double                               => DoubleVal(double)
-      case float: java.lang.Float                                 => FloatVal(float)
-      case short: java.lang.Short                                 => ShortVal(short)
-      case byteArray: Array[Byte]                                 => ByteArrayVal(ByteVector(byteArray))
-      case b: java.lang.Boolean                                   => BooleanVal(b)
-      case i: java.lang.Integer                                   => IntVal(i)
-      case l: java.lang.Long                                      => LongVal(l)
-      case s: java.lang.String                                    => StringVal(s)
-      case ls: LongString                                         => StringVal(ls.toString)
+      case byte: java.lang.Byte     => ByteVal(byte)
+      case double: java.lang.Double => DoubleVal(double)
+      case float: java.lang.Float   => FloatVal(float)
+      case short: java.lang.Short   => ShortVal(short)
+      case byteArray: Array[Byte]   => ByteArrayVal(ByteVector(byteArray))
+      case b: java.lang.Boolean     => BooleanVal(b)
+      case i: java.lang.Integer     => IntVal(i)
+      case l: java.lang.Long        => LongVal(l)
+      case s: java.lang.String      => StringVal(s)
+      case ls: LongString           => StringVal(ls.toString)
       // Looking at com.rabbitmq.client.impl.ValueReader.readFieldValue reveals
       // that java.util.Lists must always be created by
       // com.rabbitmq.client.impl.ValueReader.readArray, whose values must are
@@ -349,8 +347,8 @@ object model {
       // that the inner type can never be anything other than the types
       // represented by AmqpHeaderVal
       // This makes us safe from ClassCastExceptions down the road.
-      case a: java.util.List[AnyRef @unchecked]                   => ArrayVal(a.asScala.toVector.map(unsafeFrom))
-      case null                                                   => NullVal
+      case a: java.util.List[AnyRef @unchecked] => ArrayVal(a.asScala.toVector.map(unsafeFrom))
+      case null                                 => NullVal
     }
 
     implicit val amqpFieldValueEq: Eq[AmqpFieldValue] = new Eq[AmqpFieldValue] {
@@ -445,8 +443,9 @@ object model {
         timestamp = Option(basicProps.getTimestamp).map(_.toInstant),
         headers = Option(basicProps.getHeaders)
           .fold(Map.empty[String, Object])(_.asScala.toMap)
-          .map { case (k, v) =>
-            k -> AmqpFieldValue.unsafeFrom(v)
+          .map {
+            case (k, v) =>
+              k -> AmqpFieldValue.unsafeFrom(v)
           }
       )
 

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -105,8 +105,9 @@ object model {
     final case class Reject(deliveryTag: DeliveryTag) extends AckResult
   }
 
-  /**
-    * A string whose UTF-8 encoded representation is 255 bytes or less.
+  final case class AckMultiple(multiple: Boolean) extends AnyVal
+
+  /** A string whose UTF-8 encoded representation is 255 bytes or less.
     *
     * Parts of the AMQP spec call for the use of such strings.
     */
@@ -121,8 +122,7 @@ object model {
         None
       }
 
-    /**
-      * This bypasses the safety check that [[from]] has. This is meant only for
+    /** This bypasses the safety check that [[from]] has. This is meant only for
       * situations where you are certain the string cannot be larger than
       * [[MaxByteLength]] (e.g. string literals).
       */
@@ -132,8 +132,7 @@ object model {
     implicit val shortStringOrdering: Ordering[ShortString] = Order[ShortString].toOrdering
   }
 
-  /**
-    * This hierarchy is meant to reflect the output of
+  /** This hierarchy is meant to reflect the output of
     * [[com.rabbitmq.client.impl.ValueReader.readFieldValue]] in a type-safe
     * way.
     *
@@ -157,8 +156,7 @@ object model {
     */
   sealed trait AmqpFieldValue extends Product with Serializable {
 
-    /**
-      * The opposite of [[AmqpFieldValue.unsafeFrom]]. Turns an [[AmqpFieldValue]]
+    /** The opposite of [[AmqpFieldValue.unsafeFrom]]. Turns an [[AmqpFieldValue]]
       * into something that can be processed by
       * [[com.rabbitmq.client.impl.ValueWriter]].
       */
@@ -167,8 +165,7 @@ object model {
 
   object AmqpFieldValue {
 
-    /**
-      * A type for AMQP timestamps.
+    /** A type for AMQP timestamps.
       *
       * Note that this is only accurate to the second (as supported by the AMQP
       * spec and the underlying RabbitMQ implementation).
@@ -186,8 +183,7 @@ object model {
         Order.by[TimestampVal, Instant](_.instantWithOneSecondAccuracy)(instantOrderWithSecondPrecision)
     }
 
-    /**
-      * A type for precise decimal values. Note that while it is backed by a
+    /** A type for precise decimal values. Note that while it is backed by a
       * [[BigDecimal]] (just like the underlying Java library), there is a limit
       * on the size and precision of the decimal: its unscaled representation cannot
       * exceed 4 bytes due to the AMQP spec and its scale component must be an octet.
@@ -200,21 +196,21 @@ object model {
 
       val MaxScaleValue: Int = 255
 
-      /**
-        * The AMQP 0.9.1 standard specifies that the scale component of a
+      /** The AMQP 0.9.1 standard specifies that the scale component of a
         * decimal must be an octet (i.e. between 0 and 255) and that its
         * unscaled component must be a 32-bit integer. If those criteria are
         * not met, then we get back None.
         */
       def from(bigDecimal: BigDecimal): Option[DecimalVal] =
-        if (getFullBitLengthOfUnscaled(bigDecimal) > MaxUnscaledBits || bigDecimal.scale > MaxScaleValue || bigDecimal.scale < 0) {
+        if (getFullBitLengthOfUnscaled(
+              bigDecimal
+            ) > MaxUnscaledBits || bigDecimal.scale > MaxScaleValue || bigDecimal.scale < 0) {
           None
         } else {
           Some(new DecimalVal(bigDecimal) {})
         }
 
-      /**
-        * Only use if you're certain that the [[BigDecimal]]'s representation
+      /** Only use if you're certain that the [[BigDecimal]]'s representation
         * meets the requirements of a [[ DecimalVal ]] (e.g. you are
         * constructing one using literals).
         *
@@ -304,8 +300,7 @@ object model {
       implicit val nullValOrder: Order[NullVal.type] = Order.allEqual
     }
 
-    /**
-      * This method is meant purely to translate the output of
+    /** This method is meant purely to translate the output of
       * [[com.rabbitmq.client.impl.ValueReader.readFieldValue]]. As such it is
       * NOT total and will blow up if you pass it a class which
       * [[com.rabbitmq.client.impl.ValueReader.readFieldValue]] does not output.
@@ -397,20 +392,22 @@ object model {
   object AmqpProperties {
     def empty = AmqpProperties()
 
-    private def tupled(p: AmqpProperties): (Option[String],
-                                            Option[String],
-                                            Option[Int],
-                                            Option[DeliveryMode],
-                                            Option[String],
-                                            Option[String],
-                                            Option[String],
-                                            Option[String],
-                                            Option[String],
-                                            Option[String],
-                                            Option[String],
-                                            Option[String],
-                                            Option[Instant],
-                                            Map[String, AmqpFieldValue]) =
+    private def tupled(p: AmqpProperties): (
+        Option[String],
+        Option[String],
+        Option[Int],
+        Option[DeliveryMode],
+        Option[String],
+        Option[String],
+        Option[String],
+        Option[String],
+        Option[String],
+        Option[String],
+        Option[String],
+        Option[String],
+        Option[Instant],
+        Map[String, AmqpFieldValue]
+    ) =
       p match {
         case AmqpProperties(a, b, c, d, e, f, g, h, i, j, k, l, m, n) => (a, b, c, d, e, f, g, h, i, j, k, l, m, n)
       }
@@ -420,8 +417,7 @@ object model {
       Eq.by(ap => tupled(ap))
     }
 
-    /**
-      * It is possible to construct an [[AMQP.BasicProperties]] that will cause
+    /** It is possible to construct an [[AMQP.BasicProperties]] that will cause
       * this method to crash, hence it is unsafe. It is meant to be passed
       * values that are created by the underlying RabbitMQ Java client library
       * or other values that you are certain are well-formed (that is they
@@ -448,7 +444,8 @@ object model {
         headers = Option(basicProps.getHeaders)
           .fold(Map.empty[String, Object])(_.asScala.toMap)
           .map {
-            case (k, v) => k -> AmqpFieldValue.unsafeFrom(v)
+            case (k, v) =>
+              k -> AmqpFieldValue.unsafeFrom(v)
           }
       )
 
@@ -516,7 +513,7 @@ object model {
               Eq.by(_.exchangeName),
               Eq.and(Eq.by(_.routingKey), Eq.by(_.redelivered))
             )
-          ),
+          )
         )
       )
   }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -49,25 +49,25 @@ object model {
   case class RabbitConnection(value: Connection) extends AMQPConnection
 
   case class ExchangeName(value: String) extends AnyVal
-  object ExchangeName extends (String => ExchangeName) {
+  object ExchangeName                    extends (String => ExchangeName) {
     implicit val exchangeNameOrder: Order[ExchangeName] = Order.by(_.value)
   }
-  case class QueueName(value: String) extends AnyVal
-  object QueueName extends (String => QueueName) {
+  case class QueueName(value: String)    extends AnyVal
+  object QueueName                       extends (String => QueueName)    {
     implicit val queueNameOrder: Order[QueueName] = Order.by(_.value)
   }
-  case class RoutingKey(value: String) extends AnyVal
-  object RoutingKey extends (String => RoutingKey) {
+  case class RoutingKey(value: String)   extends AnyVal
+  object RoutingKey                      extends (String => RoutingKey)   {
     implicit val routingKeyOrder: Order[RoutingKey] = Order.by(_.value)
   }
-  case class DeliveryTag(value: Long) extends AnyVal
-  object DeliveryTag extends (Long => DeliveryTag) {
-    implicit val deliveryTagOrder: Order[DeliveryTag] = Order.by(_.value)
+  case class DeliveryTag(value: Long)    extends AnyVal
+  object DeliveryTag                     extends (Long => DeliveryTag)    {
+    implicit val deliveryTagOrder: Order[DeliveryTag]                               = Order.by(_.value)
     implicit val deliveryTagCommutativeSemigroup: CommutativeSemigroup[DeliveryTag] =
       CommutativeSemigroup.instance(_ max _)
   }
-  case class ConsumerTag(value: String) extends AnyVal
-  object ConsumerTag extends (String => ConsumerTag) {
+  case class ConsumerTag(value: String)  extends AnyVal
+  object ConsumerTag                     extends (String => ConsumerTag)  {
     implicit val consumerTagOrder: Order[ConsumerTag] = Order.by(_.value)
   }
 
@@ -177,7 +177,7 @@ object model {
       def from(instant: Instant): TimestampVal =
         new TimestampVal(instant.truncatedTo(ChronoUnit.SECONDS)) {}
 
-      def from(date: Date): TimestampVal = from(date.toInstant)
+      def from(date: Date): TimestampVal       = from(date.toInstant)
 
       implicit val timestampOrder: Order[TimestampVal] =
         Order.by[TimestampVal, Instant](_.instantWithOneSecondAccuracy)(instantOrderWithSecondPrecision)
@@ -202,9 +202,11 @@ object model {
         * not met, then we get back None.
         */
       def from(bigDecimal: BigDecimal): Option[DecimalVal] =
-        if (getFullBitLengthOfUnscaled(
-              bigDecimal
-            ) > MaxUnscaledBits || bigDecimal.scale > MaxScaleValue || bigDecimal.scale < 0) {
+        if (
+          getFullBitLengthOfUnscaled(bigDecimal) > MaxUnscaledBits ||
+          bigDecimal.scale > MaxScaleValue ||
+          bigDecimal.scale < 0
+        ) {
           None
         } else {
           Some(new DecimalVal(bigDecimal) {})
@@ -216,7 +218,7 @@ object model {
         *
         * Almost always you should be using [[from]].
         */
-      def unsafeFrom(bigDecimal: BigDecimal): DecimalVal =
+      def unsafeFrom(bigDecimal: BigDecimal): DecimalVal                  =
         new DecimalVal(bigDecimal) {}
 
       private def getFullBitLengthOfUnscaled(bigDecimal: BigDecimal): Int =
@@ -227,74 +229,74 @@ object model {
       implicit val decimalValOrder: Order[DecimalVal] = Order.by(_.sizeLimitedBigDecimal)
     }
 
-    final case class TableVal(value: Map[ShortString, AmqpFieldValue]) extends AmqpFieldValue {
+    final case class TableVal(value: Map[ShortString, AmqpFieldValue]) extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.util.Map[String, AnyRef] =
         value.map { case (key, v) => key.str -> v.toValueWriterCompatibleJava }.asJava
     }
-    object TableVal extends (Map[ShortString, AmqpFieldValue] => TableVal) {
+    object TableVal                                                    extends (Map[ShortString, AmqpFieldValue] => TableVal) {
       implicit val tableValEq: Eq[TableVal] = Eq.by(_.value)
     }
-    final case class ByteVal(value: Byte) extends AmqpFieldValue {
+    final case class ByteVal(value: Byte)                              extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.lang.Byte = Byte.box(value)
     }
-    object ByteVal extends (Byte => ByteVal) {
+    object ByteVal                                                     extends (Byte => ByteVal)                              {
       implicit val byteValOrder: Order[ByteVal] = Order.by(_.value)
     }
-    final case class DoubleVal(value: Double) extends AmqpFieldValue {
+    final case class DoubleVal(value: Double)                          extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.lang.Double = Double.box(value)
     }
-    object DoubleVal extends (Double => DoubleVal) {
+    object DoubleVal                                                   extends (Double => DoubleVal)                          {
       implicit val doubleValOrder: Order[DoubleVal] = Order.by(_.value)
     }
-    final case class FloatVal(value: Float) extends AmqpFieldValue {
+    final case class FloatVal(value: Float)                            extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.lang.Float = Float.box(value)
     }
-    object FloatVal extends (Float => FloatVal) {
+    object FloatVal                                                    extends (Float => FloatVal)                            {
       implicit val floatValOrder: Order[FloatVal] = Order.by(_.value)
     }
-    final case class ShortVal(value: Short) extends AmqpFieldValue {
+    final case class ShortVal(value: Short)                            extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.lang.Short = Short.box(value)
     }
-    object ShortVal extends (Short => ShortVal) {
+    object ShortVal                                                    extends (Short => ShortVal)                            {
       implicit val shortValOrder: Order[ShortVal] = Order.by(_.value)
     }
-    final case class ByteArrayVal(value: ByteVector) extends AmqpFieldValue {
+    final case class ByteArrayVal(value: ByteVector)                   extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: Array[Byte] = value.toArray
     }
-    object ByteArrayVal extends (ByteVector => ByteArrayVal) {
+    object ByteArrayVal                                                extends (ByteVector => ByteArrayVal)                   {
       implicit val byteArrayValEq: Eq[ByteArrayVal] = Eq.by(_.value)
     }
-    final case class BooleanVal(value: Boolean) extends AmqpFieldValue {
+    final case class BooleanVal(value: Boolean)                        extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.lang.Boolean = Boolean.box(value)
     }
-    object BooleanVal extends (Boolean => BooleanVal) {
+    object BooleanVal                                                  extends (Boolean => BooleanVal)                        {
       implicit val booleanValOrder: Order[BooleanVal] = Order.by(_.value)
     }
-    final case class IntVal(value: Int) extends AmqpFieldValue {
+    final case class IntVal(value: Int)                                extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.lang.Integer = Int.box(value)
     }
-    object IntVal extends (Int => IntVal) {
+    object IntVal                                                      extends (Int => IntVal)                                {
       implicit val intValOrder: Order[IntVal] = Order.by(_.value)
     }
-    final case class LongVal(value: Long) extends AmqpFieldValue {
+    final case class LongVal(value: Long)                              extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.lang.Long = Long.box(value)
     }
-    object LongVal extends (Long => LongVal) {
+    object LongVal                                                     extends (Long => LongVal)                              {
       implicit val longValOrder: Order[LongVal] = Order.by(_.value)
     }
-    final case class StringVal(value: String) extends AmqpFieldValue {
+    final case class StringVal(value: String)                          extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: String = value
     }
-    object StringVal extends (String => StringVal) {
+    object StringVal                                                   extends (String => StringVal)                          {
       implicit val stringValOrder: Order[StringVal] = Order.by(_.value)
     }
-    final case class ArrayVal(value: Vector[AmqpFieldValue]) extends AmqpFieldValue {
+    final case class ArrayVal(value: Vector[AmqpFieldValue])           extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: java.util.List[AnyRef] = value.map(_.toValueWriterCompatibleJava).asJava
     }
-    object ArrayVal extends (Vector[AmqpFieldValue] => ArrayVal) {
+    object ArrayVal                                                    extends (Vector[AmqpFieldValue] => ArrayVal)           {
       implicit val arrayValEq: Eq[ArrayVal] = Eq.by(_.value)
     }
-    case object NullVal extends AmqpFieldValue {
+    case object NullVal                                                extends AmqpFieldValue                                 {
       override def toValueWriterCompatibleJava: Null = null
 
       implicit val nullValOrder: Order[NullVal.type] = Order.allEqual
@@ -314,9 +316,9 @@ object model {
       // representation size must have already occurred because ValueReader will
       // only read a maximum of 4 bytes before bailing out (similarly it will
       // read no more than the first 8 bits to determine scale).
-      case bd: java.math.BigDecimal => DecimalVal.unsafeFrom(bd)
-      case ts: java.time.Instant    => TimestampVal.from(ts)
-      case d: java.util.Date        => TimestampVal.from(d)
+      case bd: java.math.BigDecimal                               => DecimalVal.unsafeFrom(bd)
+      case ts: java.time.Instant                                  => TimestampVal.from(ts)
+      case d: java.util.Date                                      => TimestampVal.from(d)
       // Looking at com.rabbitmq.client.impl.ValueReader.readFieldValue reveals
       // that java.util.Maps must always be created by
       // com.rabbitmq.client.impl.ValueReader.readTable, whose Maps must always
@@ -329,16 +331,16 @@ object model {
         // one byte to determine how large of a byte array to allocate for the
         // string which means the length cannot possibly exceed 255.
         TableVal(t.asScala.toMap.map { case (key, v) => ShortString.unsafeFrom(key) -> unsafeFrom(v) })
-      case byte: java.lang.Byte     => ByteVal(byte)
-      case double: java.lang.Double => DoubleVal(double)
-      case float: java.lang.Float   => FloatVal(float)
-      case short: java.lang.Short   => ShortVal(short)
-      case byteArray: Array[Byte]   => ByteArrayVal(ByteVector(byteArray))
-      case b: java.lang.Boolean     => BooleanVal(b)
-      case i: java.lang.Integer     => IntVal(i)
-      case l: java.lang.Long        => LongVal(l)
-      case s: java.lang.String      => StringVal(s)
-      case ls: LongString           => StringVal(ls.toString)
+      case byte: java.lang.Byte                                   => ByteVal(byte)
+      case double: java.lang.Double                               => DoubleVal(double)
+      case float: java.lang.Float                                 => FloatVal(float)
+      case short: java.lang.Short                                 => ShortVal(short)
+      case byteArray: Array[Byte]                                 => ByteArrayVal(ByteVector(byteArray))
+      case b: java.lang.Boolean                                   => BooleanVal(b)
+      case i: java.lang.Integer                                   => IntVal(i)
+      case l: java.lang.Long                                      => LongVal(l)
+      case s: java.lang.String                                    => StringVal(s)
+      case ls: LongString                                         => StringVal(ls.toString)
       // Looking at com.rabbitmq.client.impl.ValueReader.readFieldValue reveals
       // that java.util.Lists must always be created by
       // com.rabbitmq.client.impl.ValueReader.readArray, whose values must are
@@ -347,8 +349,8 @@ object model {
       // that the inner type can never be anything other than the types
       // represented by AmqpHeaderVal
       // This makes us safe from ClassCastExceptions down the road.
-      case a: java.util.List[AnyRef @unchecked] => ArrayVal(a.asScala.toVector.map(unsafeFrom))
-      case null                                 => NullVal
+      case a: java.util.List[AnyRef @unchecked]                   => ArrayVal(a.asScala.toVector.map(unsafeFrom))
+      case null                                                   => NullVal
     }
 
     implicit val amqpFieldValueEq: Eq[AmqpFieldValue] = new Eq[AmqpFieldValue] {
@@ -443,9 +445,8 @@ object model {
         timestamp = Option(basicProps.getTimestamp).map(_.toInstant),
         headers = Option(basicProps.getHeaders)
           .fold(Map.empty[String, Object])(_.asScala.toMap)
-          .map {
-            case (k, v) =>
-              k -> AmqpFieldValue.unsafeFrom(v)
+          .map { case (k, v) =>
+            k -> AmqpFieldValue.unsafeFrom(v)
           }
       )
 

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
@@ -37,7 +37,8 @@ case class WrapperAckingProgram[F[_]: Sync] private (
     consume: Consume[F]
 ) extends AckingProgram[F] {
   override def createAcker(channel: AMQPChannel, multiple: AckMultiple): F[AckResult => F[Unit]] = Applicative[F].pure {
-    ackResult => _createAckerWithMultipleFlag(channel)(ackResult, multiple)
+    ackResult =>
+      _createAckerWithMultipleFlag(channel)(ackResult, multiple)
   }
 
   override def createAckerWithMultipleFlag(channel: AMQPChannel): F[(AckResult, AckMultiple) => F[Unit]] =
@@ -46,10 +47,10 @@ case class WrapperAckingProgram[F[_]: Sync] private (
     }
 
   private def _createAckerWithMultipleFlag(channel: AMQPChannel): (AckResult, AckMultiple) => F[Unit] = {
-    case (Ack(tag), flag)  => consume.basicAck(channel, tag, multiple = flag.multiple)
+    case (Ack(tag), flag) => consume.basicAck(channel, tag, multiple = flag.multiple)
     case (NAck(tag), flag) =>
       consume.basicNack(channel, tag, multiple = flag.multiple, config.requeueOnNack)
-    case (Reject(tag), _)  =>
+    case (Reject(tag), _) =>
       consume.basicReject(channel, tag, config.requeueOnReject)
   }
 

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgramOps.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgramOps.scala
@@ -23,9 +23,9 @@ import dev.profunktor.fs2rabbit.model._
 
 final class PublishingProgramOps[F[_]](val prog: PublishingProgram[F]) extends AnyVal {
   def imapK[G[_]](fk: F ~> G)(gk: G ~> F)(implicit F: Functor[F]): PublishingProgram[G] = new PublishingProgram[G] {
-    def createPublisher[A](channel: AMQPChannel, exchangeName: ExchangeName, routingKey: RoutingKey)(implicit
-        encoder: MessageEncoder[G, A]
-    ): G[A => G[Unit]] =
+    def createPublisher[A](channel: AMQPChannel, exchangeName: ExchangeName, routingKey: RoutingKey)(
+        implicit
+        encoder: MessageEncoder[G, A]): G[A => G[Unit]] =
       fk(
         prog.createPublisher[A](channel, exchangeName, routingKey)(encoder.mapK(gk)).map(_.andThen(fk.apply))
       )
@@ -45,9 +45,9 @@ final class PublishingProgramOps[F[_]](val prog: PublishingProgram[F]) extends A
           .map(_.andThen(fk.apply))
       )
 
-    def createRoutingPublisher[A](channel: AMQPChannel, exchangeName: ExchangeName)(implicit
-        encoder: MessageEncoder[G, A]
-    ): G[RoutingKey => A => G[Unit]] =
+    def createRoutingPublisher[A](channel: AMQPChannel, exchangeName: ExchangeName)(
+        implicit
+        encoder: MessageEncoder[G, A]): G[RoutingKey => A => G[Unit]] =
       fk(
         prog.createRoutingPublisher[A](channel, exchangeName)(encoder.mapK(gk)).map {
           f => (routingKey: RoutingKey) => (a: A) =>
@@ -75,8 +75,9 @@ final class PublishingProgramOps[F[_]](val prog: PublishingProgram[F]) extends A
         channel: AMQPChannel
     )(implicit encoder: MessageEncoder[G, A]): G[(ExchangeName, RoutingKey, A) => G[Unit]] =
       fk(prog.createBasicPublisher[A](channel)(encoder.mapK(gk)).map { f =>
-        { case (e, r, a) =>
-          fk(f(e, r, a))
+        {
+          case (e, r, a) =>
+            fk(f(e, r, a))
         }
       })
 
@@ -89,8 +90,9 @@ final class PublishingProgramOps[F[_]](val prog: PublishingProgram[F]) extends A
         prog
           .createBasicPublisherWithListener[A](channel, flags, listener.andThen(gk.apply))(encoder.mapK(gk))
           .map { f =>
-            { case (e, r, a) =>
-              fk(f(e, r, a))
+            {
+              case (e, r, a) =>
+                fk(f(e, r, a))
             }
           }
       )


### PR DESCRIPTION
Addresses #461

- adds a new function to rabbit client: `createAckerConsumerWithMultipleFlag` which returns an acker function `(AckResult, AckMultiple) => F[Unit]` args as oppose to `createAckerConsumer`'s return type of `AckResult => F[Unit]`. 

- adds an arg to `createAckerConsumer` to set the ack multiple flag for the entire lifetime of the created consumer. 

(sorry, scalafmt rules are on a rampage since I turned it on in my ide)