### PR TITLE
Add support for basic.get

### DIFF
--- a/core/src/main/scala-2.13/dev/profunktor/fs2rabbit/javaConversion.scala
+++ b/core/src/main/scala-2.13/dev/profunktor/fs2rabbit/javaConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AMQPInternals.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AMQPInternals.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AckConsuming.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/AckConsuming.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Acking.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Acking.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Binding.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Binding.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/BindingOps.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/BindingOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Cancel.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Cancel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Connection.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Consume.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Consume.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,24 @@
 
 package dev.profunktor.fs2rabbit.algebra
 
+import cats.Applicative
+import cats.Functor
 import cats.effect.kernel.Sync
 import cats.effect.std.Dispatcher
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import cats.{Applicative, Functor}
-import com.rabbitmq.client.{AMQP, Consumer, DefaultConsumer, Envelope, ShutdownSignalException}
-import dev.profunktor.fs2rabbit.arguments.{Arguments, _}
+import com.rabbitmq.client.AMQP
+import com.rabbitmq.client.Consumer
+import com.rabbitmq.client.DefaultConsumer
+import com.rabbitmq.client.Envelope
+import com.rabbitmq.client.ShutdownSignalException
+import dev.profunktor.fs2rabbit.arguments.Arguments
+import dev.profunktor.fs2rabbit.arguments._
 import dev.profunktor.fs2rabbit.model._
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 object Consume {
   def make[F[_]: Sync](dispatcher: Dispatcher[F]): Consume[F] =

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Consuming.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Consuming.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Declaration.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Declaration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/DeclarationOps.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/DeclarationOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Deletion.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Deletion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/DeletionOps.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/DeletionOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Get.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Get.scala
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017-2023 ProfunKtor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.profunktor.fs2rabbit.algebra
+
+import cats.effect.Sync
+import cats.syntax.functor._
+import cats.syntax.applicative._
+import cats.syntax.either._
+import cats.syntax.option._
+import com.rabbitmq.client.AMQP
+import com.rabbitmq.client.Envelope
+import dev.profunktor.fs2rabbit.model._
+
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
+
+object Get {
+  def make[F[_]: Sync]: Get[F] = new Get[F] {
+    override def basicAck(channel: AMQPChannel, tag: DeliveryTag, multiple: Boolean): F[Unit] = Sync[F].blocking {
+      channel.value.basicAck(tag.value, multiple)
+    }
+
+    override def basicNack(channel: AMQPChannel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit] =
+      Sync[F].blocking {
+        channel.value.basicNack(tag.value, multiple, requeue)
+      }
+
+    override def basicReject(channel: AMQPChannel, tag: DeliveryTag, requeue: Boolean): F[Unit] = Sync[F].blocking {
+      channel.value.basicReject(tag.value, requeue)
+    }
+
+    private def toEnvelope(
+        envelope: Envelope,
+        properties: AMQP.BasicProperties,
+        body: Array[Byte]
+    ): Either[Throwable, AmqpEnvelope[Array[Byte]]] = {
+      def rewrappedError(err: Throwable) =
+        Left(
+          new Exception(
+            s"""
+                You've stumbled across a bug in the interface between the underlying
+                RabbitMQ Java library and fs2-rabbit! Please report this bug and
+                include this stack trace and message.\n
+
+                The BasicProperties instance that caused this error was:\n
+
+                $properties
+                """,
+            err
+          )
+        )
+
+      val amqpPropertiesOrErr =
+        Try(AmqpProperties.unsafeFrom(properties)) match {
+          case Success(p) => Right(p)
+          case Failure(t) => rewrappedError(t)
+        }
+
+      val tag         = envelope.getDeliveryTag
+      val routingKey  = RoutingKey(envelope.getRoutingKey)
+      val exchange    = ExchangeName(envelope.getExchange)
+      val redelivered = envelope.isRedeliver
+
+      // Calling the Functor instance manually for compatibility
+
+      amqpPropertiesOrErr.map { props =>
+        AmqpEnvelope(
+          DeliveryTag(tag),
+          body,
+          props,
+          exchange,
+          routingKey,
+          redelivered
+        )
+      }
+    }
+
+    override def basicGet(
+        channel: AMQPChannel,
+        queue: QueueName,
+        autoAck: Boolean
+    ): F[Either[Throwable, Option[AmqpEnvelope[Array[Byte]]]]] = Sync[F]
+      .blocking {
+        val resp = channel.value.basicGet(queue.value, autoAck)
+        if (resp != null) Some(resp) else None
+      }
+      .map {
+        case None       => none[AmqpEnvelope[Array[Byte]]].asRight[Throwable]
+        case Some(resp) => toEnvelope(resp.getEnvelope, resp.getProps, resp.getBody).map(_.some)
+      }
+  }
+}
+
+trait Get[F[_]] {
+  def basicAck(channel: AMQPChannel, tag: DeliveryTag, multiple: Boolean): F[Unit]
+  def basicNack(channel: AMQPChannel, tag: DeliveryTag, multiple: Boolean, requeue: Boolean): F[Unit]
+  def basicReject(channel: AMQPChannel, tag: DeliveryTag, requeue: Boolean): F[Unit]
+  def basicGet(
+      channel: AMQPChannel,
+      queue: QueueName,
+      autoAck: Boolean
+  ): F[Either[Throwable, Option[AmqpEnvelope[Array[Byte]]]]]
+}

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Getting.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Getting.scala
@@ -16,24 +16,13 @@
 
 package dev.profunktor.fs2rabbit.algebra
 
-import dev.profunktor.fs2rabbit.arguments.Arguments
 import dev.profunktor.fs2rabbit.effects.EnvelopeDecoder
-import dev.profunktor.fs2rabbit.model._
-import fs2.Stream
+import dev.profunktor.fs2rabbit.model.AMQPChannel
+import dev.profunktor.fs2rabbit.model.AmqpEnvelope
+import dev.profunktor.fs2rabbit.model.QueueName
 
-object ConsumingStream {
-  type ConsumingStream[F[_]] = Consuming[F, Stream[F, *]]
-}
-
-trait Consuming[F[_], R[_]] extends Getting[F] {
-  def createConsumer[A](
-      queueName: QueueName,
-      channel: AMQPChannel,
-      basicQos: BasicQos,
-      autoAck: Boolean = false,
-      noLocal: Boolean = false,
-      exclusive: Boolean = false,
-      consumerTag: ConsumerTag = ConsumerTag(""),
-      args: Arguments = Map.empty
-  )(implicit decoder: EnvelopeDecoder[F, A]): F[R[AmqpEnvelope[A]]]
+trait Getting[F[_]] {
+  def get[A](queue: QueueName, channel: AMQPChannel, autoAck: Boolean)(implicit
+      decoder: EnvelopeDecoder[F, A]
+  ): F[Option[AmqpEnvelope[A]]]
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/InternalQueue.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/InternalQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Publish.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Publish.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Publishing.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/algebra/Publishing.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/arguments.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/arguments.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/Fs2RabbitConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/declaration.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/declaration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/deletion.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/deletion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/effects/BoolValue.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/effects/BoolValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/effects/EnvelopeDecoder.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/effects/EnvelopeDecoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/effects/Log.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/effects/Log.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/effects/StreamEval.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/effects/StreamEval.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/effects/package.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/effects/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/LiveInternalQueue.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/LiveInternalQueue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
@@ -471,4 +471,17 @@ class RabbitClient[F[_]] private[fs2rabbit] (
       config: DeletionExchangeConfig
   )(implicit channel: AMQPChannel): F[Unit] =
     deletion.deleteExchangeNoWait(channel, config)
+
+  def getAndAck[A](
+      queueName: QueueName
+  )(implicit channel: AMQPChannel, decoder: EnvelopeDecoder[F, A]): F[Option[AmqpEnvelope[A]]] =
+    consumingProgram.get(queueName, channel, true)
+
+  def get[A](
+      queueName: QueueName
+  )(implicit channel: AMQPChannel, decoder: EnvelopeDecoder[F, A]): F[Option[AmqpEnvelope[A]]] =
+    consumingProgram.get(queueName, channel, false)
+
+  def createAcker(implicit channel: AMQPChannel): F[AckResult => F[Unit]] =
+    consumingProgram.createAcker(channel, AckMultiple(false))
 }

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClientOps.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClientOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckConsumingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckConsumingProgram.scala
@@ -106,6 +106,11 @@ case class WrapperAckConsumingProgram[F[_]: Sync] private[program] (
   )(implicit decoder: EnvelopeDecoder[F, A]): F[Stream[F, AmqpEnvelope[A]]] =
     consumingProgram.createConsumer(queueName, channel, basicQos, autoAck, noLocal, exclusive, consumerTag, args)
 
+  override def get[A](queue: QueueName, channel: AMQPChannel, autoAck: Boolean)(implicit
+      decoder: EnvelopeDecoder[F, A]
+  ): F[Option[AmqpEnvelope[A]]] =
+    consumingProgram.get(queue, channel, autoAck)
+
   override def createAcker(channel: AMQPChannel, ackMultiple: AckMultiple): F[AckResult => F[Unit]] =
     ackingProgram.createAcker(channel, ackMultiple)
 

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckConsumingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckConsumingProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckConsumingProgramOps.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckConsumingProgramOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckConsumingProgramOps.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckConsumingProgramOps.scala
@@ -44,6 +44,11 @@ final class AckConsumingProgramOps[F[_]](val prog: AckConsumingProgram[F]) exten
             .map(_.translate(fk))
         )
 
+      def get[A](queue: QueueName, channel: AMQPChannel, autoAck: Boolean)(implicit
+          decoder: EnvelopeDecoder[G, A]
+      ): G[Option[AmqpEnvelope[A]]] =
+        fk(prog.get(queue, channel, autoAck)(decoder.mapK(gk)))
+
       def createAcker(channel: AMQPChannel, ackMultiple: AckMultiple): G[AckResult => G[Unit]] =
         fk(prog.createAcker(channel, ackMultiple).map(_.andThen(fk.apply)))
 

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/AckingProgram.scala
@@ -66,6 +66,13 @@ case class WrapperAckingProgram[F[_]: Sync] private[program] (
   override def basicQos(channel: AMQPChannel, basicQos: BasicQos): F[Unit] =
     consume.basicQos(channel, basicQos)
 
+  override def basicGet(
+      channel: AMQPChannel,
+      queue: QueueName,
+      autoAck: Boolean
+  ): F[Either[Throwable, Option[AmqpEnvelope[Array[Byte]]]]] =
+    consume.basicGet(channel, queue, autoAck)
+
   override def basicConsume[A](
       channel: AMQPChannel,
       queueName: QueueName,

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/ConsumingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/ConsumingProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgram.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgramOps.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/program/PublishingProgramOps.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/resiliency/ResilientStream.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/resiliency/ResilientStream.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpFieldValueSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpFieldValueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/SafeArgSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/SafeArgSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/effects/EnvelopeDecoderSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/effects/EnvelopeDecoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/AckerConsumerDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/AckerConsumerDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/AutoAckConsumerDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/AutoAckConsumerDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/DropwizardMetricsDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/DropwizardMetricsDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/IOAckerConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/MonixAutoAckConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/RPCDemo.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/RPCDemo.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/ZIOAutoAckConsumer.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/ZIOAutoAckConsumer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/package.scala
+++ b/examples/src/main/scala/dev/profunktor/fs2rabbit/examples/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-circe/src/main/scala/dev/profunktor/fs2rabbit/json/Fs2JsonDecoder.scala
+++ b/json-circe/src/main/scala/dev/profunktor/fs2rabbit/json/Fs2JsonDecoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-circe/src/main/scala/dev/profunktor/fs2rabbit/json/Fs2JsonEncoder.scala
+++ b/json-circe/src/main/scala/dev/profunktor/fs2rabbit/json/Fs2JsonEncoder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonDecoderSpec.scala
+++ b/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonDecoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonEncoderSpec.scala
+++ b/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonEncoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/shell.nix
+++ b/shell.nix
@@ -25,5 +25,7 @@ in
       jekyll # 4.1.0
       openjdk11 # 11.0.6-internal
       sbt # 1.3.12
+      bloop
+      docker-compose
     ];
   }

--- a/testkit/src/main/scala/dev/profunktor/fs2rabbit/testkit/package.scala
+++ b/testkit/src/main/scala/dev/profunktor/fs2rabbit/testkit/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/BaseSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,25 +16,26 @@
 
 package dev.profunktor.fs2rabbit.interpreter
 
+import cats.data.Kleisli
 import cats.effect._
+import cats.effect.kernel.Deferred
+import cats.effect.unsafe.implicits.global
 import cats.implicits._
+import dev.profunktor.fs2rabbit.BaseSpec
 import dev.profunktor.fs2rabbit.config.Fs2RabbitConfig
 import dev.profunktor.fs2rabbit.config.declaration._
-import dev.profunktor.fs2rabbit.config.deletion.{DeletionExchangeConfig, DeletionQueueConfig}
-import dev.profunktor.fs2rabbit.model.AckResult.{Ack, NAck, Reject}
+import dev.profunktor.fs2rabbit.config.deletion.DeletionExchangeConfig
+import dev.profunktor.fs2rabbit.config.deletion.DeletionQueueConfig
+import dev.profunktor.fs2rabbit.model.AckResult.Ack
+import dev.profunktor.fs2rabbit.model.AckResult.NAck
+import dev.profunktor.fs2rabbit.model.AckResult.Reject
 import dev.profunktor.fs2rabbit.model._
-import dev.profunktor.fs2rabbit.BaseSpec
 import fs2.Stream
 import org.scalatest.Assertion
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Random
-import scala.concurrent.Future
-
-import cats.effect.unsafe.implicits.global
-
-import cats.effect.kernel.Deferred
-import cats.data.Kleisli
 
 trait Fs2RabbitSpec { self: BaseSpec =>
 

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/RabbitSuite.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/RabbitSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/CommutativeSemigroupInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/CommutativeSemigroupInstancesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/EqInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/EqInstancesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/OrderInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/OrderInstancesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/TraverseInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/TraverseInstancesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/resiliency/ResilientStreamSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/resiliency/ResilientStreamSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds support for [AMQPs `basic.get`](https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get) method. I tried to isolate the style changes that were applied automatically in a separate commit. If you prefer separate PRs for those, please just say so.

This moves some methods that were previously defined in `Consume` into a new trait `Get` (along with the newly added `get`), which `Consume` now extends. I have to admit I was not completely sure as to what the intended separation of concerns is with all the `<Verb>`, `<Verb>ing` and `<Verb>Program` traits. I hope I didn't mess things up too very much.