### PR TITLE
Update docker compose, ci/cd, copyright year, Dispatcher deprecation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 jobs:
   build:
     name: Publish
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: "actions/checkout@v2.3.4"
       - name: java 11 setup

--- a/core/src/main/scala-2.12/dev/profunktor/fs2rabbit/javaConversion.scala
+++ b/core/src/main/scala-2.12/dev/profunktor/fs2rabbit/javaConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala-3/dev/profunktor/fs2rabbit/javaConversion.scala
+++ b/core/src/main/scala-3/dev/profunktor/fs2rabbit/javaConversion.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/interpreter/RabbitClient.scala
@@ -80,7 +80,7 @@ object RabbitClient {
       saslConfig: SaslConfig = DefaultSaslConfig.PLAIN,
       metricsCollector: Option[MetricsCollector] = None,
       threadFactory: Option[F[ThreadFactory]] = None
-  ): Resource[F, RabbitClient[F]] = Dispatcher[F].evalMap { dispatcher =>
+  ): Resource[F, RabbitClient[F]] = Dispatcher.parallel[F](await = false).evalMap { dispatcher =>
     apply[F](config, dispatcher, sslContext, saslConfig, metricsCollector, threadFactory)
   }
 
@@ -126,7 +126,7 @@ object RabbitClient {
       create[F](config, dispatcher, sslContext, saslConfig, metricsCollector, threadFactory, executionContext)
 
     def resource: Resource[F, RabbitClient[F]] =
-      Dispatcher[F].evalMap(build)
+      Dispatcher.parallel[F](await = false).evalMap(build)
   }
 
   def default[F[_]: Async](

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpFieldValueSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpFieldValueSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/AmqpPropertiesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/SafeArgSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/SafeArgSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/effects/EnvelopeDecoderSpec.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/effects/EnvelopeDecoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
-RabbitMQ:
-  restart: always
-  image: rabbitmq:alpine
-  ports:
-    - "5672:5672"
-  environment:
-    - DEBUG=false
-  volumes:
-    - ./rabbit-test-config/:/etc/rabbitmq/
+version: '3'
+services:
+  RabbitMQ:
+    restart: always
+    image: rabbitmq:alpine
+    ports:
+      - "5672:5672"
+    environment:
+      - DEBUG=false
+    volumes:
+      - ./rabbit-test-config/:/etc/rabbitmq/

--- a/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonDecoderSpec.scala
+++ b/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonDecoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonEncoderSpec.scala
+++ b/json-circe/src/test/scala/dev/profunktor/fs2rabbit/json/Fs2JsonEncoderSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/BaseSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/RabbitSuite.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/RabbitSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/CommutativeSemigroupInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/CommutativeSemigroupInstancesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/EqInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/EqInstancesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/OrderInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/OrderInstancesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/TraverseInstancesSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/laws/TraverseInstancesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/resiliency/ResilientStreamSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/resiliency/ResilientStreamSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 ProfunKtor
+ * Copyright 2017-2023 ProfunKtor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated the docker compose to v3, ubuntu github runner to 22.04, copyright year and a Dispatcher.apply usage