### PR TITLE
Add methods to setup settings fluently

### DIFF
--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/declaration.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/declaration.scala
@@ -16,11 +16,12 @@
 
 package dev.profunktor.fs2rabbit.config
 
-import dev.profunktor.fs2rabbit.arguments.Arguments
+import dev.profunktor.fs2rabbit.arguments.{Arguments, SafeArg}
 import dev.profunktor.fs2rabbit.model.{ExchangeName, ExchangeType, QueueName, QueueType}
 
 object declaration {
 
+  // ----- Queue Config -----
   final case class DeclarationQueueConfig(
       queueName: QueueName,
       durable: DurableCfg,
@@ -43,6 +44,35 @@ object declaration {
         case None                                          =>
           Right(arguments)
       }
+
+    // arguments
+    def withArguments(arguments: Arguments): DeclarationQueueConfig =
+      copy(arguments = arguments)
+
+    def withArguments(arguments: (String, SafeArg)*): DeclarationQueueConfig =
+      withArguments(arguments.toMap)
+
+    // durable
+    def withDurable: DeclarationQueueConfig =
+      copy(durable = Durable)
+
+    def withNonDurable: DeclarationQueueConfig =
+      copy(durable = NonDurable)
+
+    // autoDelete
+    def withAutoDelete: DeclarationQueueConfig =
+      copy(autoDelete = AutoDelete)
+
+    def withNonAutoDelete: DeclarationQueueConfig =
+      copy(autoDelete = NonAutoDelete)
+
+    // exclusive
+    def withExclusive: DeclarationQueueConfig =
+      copy(exclusive = Exclusive)
+
+    def withNonExclusive: DeclarationQueueConfig =
+      copy(exclusive = NonExclusive)
+
   }
   object DeclarationQueueConfig {
 
@@ -78,6 +108,7 @@ object declaration {
   case object AutoDelete     extends AutoDeleteCfg
   case object NonAutoDelete  extends AutoDeleteCfg
 
+  // ----- Exchange Config -----
   final case class DeclarationExchangeConfig(
       exchangeName: ExchangeName,
       exchangeType: ExchangeType,
@@ -85,12 +116,48 @@ object declaration {
       autoDelete: AutoDeleteCfg,
       internal: InternalCfg,
       arguments: Arguments
-  )
+  ) {
+
+    // arguments
+    def withArguments(arguments: Arguments): DeclarationExchangeConfig =
+      copy(arguments = arguments)
+
+    def withArguments(arguments: (String, SafeArg)*): DeclarationExchangeConfig =
+      withArguments(arguments.toMap)
+
+    // durable
+    def withDurable: DeclarationExchangeConfig =
+      copy(durable = Durable)
+
+    def withNonDurable: DeclarationExchangeConfig =
+      copy(durable = NonDurable)
+
+    // autoDelete
+    def withAutoDelete: DeclarationExchangeConfig =
+      copy(autoDelete = AutoDelete)
+
+    def withNonAutoDelete: DeclarationExchangeConfig =
+      copy(autoDelete = NonAutoDelete)
+
+    // internal
+    def withInternal: DeclarationExchangeConfig =
+      copy(internal = Internal)
+
+    def withNonInternal: DeclarationExchangeConfig =
+      copy(internal = NonInternal)
+  }
 
   object DeclarationExchangeConfig {
 
     def default(exchangeName: ExchangeName, exchangeType: ExchangeType): DeclarationExchangeConfig =
-      DeclarationExchangeConfig(exchangeName, exchangeType, NonDurable, NonAutoDelete, NonInternal, Map.empty)
+      DeclarationExchangeConfig(
+        exchangeName = exchangeName,
+        exchangeType = exchangeType,
+        durable = NonDurable,
+        autoDelete = NonAutoDelete,
+        internal = NonInternal,
+        arguments = Map.empty
+      )
   }
 
   sealed trait InternalCfg extends Product with Serializable

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/config/deletion.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/config/deletion.scala
@@ -27,15 +27,33 @@ object deletion {
   )
 
   object DeletionQueueConfig {
+
+    @deprecated("Use ifUnusedAndEmpty instead", "5.3.0")
     def default(queueName: QueueName): DeletionQueueConfig =
+      onlyIfUnusedAndEmpty(queueName)
+
+    def onlyIfUnusedAndEmpty(queueName: QueueName): DeletionQueueConfig =
       DeletionQueueConfig(queueName, Unused, Empty)
+
+    def evenIfUsedButEmpty(queueName: QueueName): DeletionQueueConfig =
+      DeletionQueueConfig(queueName, Used, Empty)
+
+    def evenIfUsedAndNonEmpty(queueName: QueueName): DeletionQueueConfig =
+      DeletionQueueConfig(queueName, Used, NonEmpty)
   }
 
   final case class DeletionExchangeConfig(exchangeName: ExchangeName, ifUnused: IfUnusedCfg)
-
   object DeletionExchangeConfig {
+
+    @deprecated("Use ifUnused instead", "5.3.0")
     def default(exchangeName: ExchangeName): DeletionExchangeConfig =
+      onlyIfUnused(exchangeName)
+
+    def onlyIfUnused(exchangeName: ExchangeName): DeletionExchangeConfig =
       DeletionExchangeConfig(exchangeName, Unused)
+
+    def evenIfUsed(exchangeName: ExchangeName): DeletionExchangeConfig =
+      DeletionExchangeConfig(exchangeName, Used)
   }
 
   sealed trait IfEmptyCfg extends Product with Serializable

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model/AmqpProperties.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model/AmqpProperties.scala
@@ -81,7 +81,7 @@ object AmqpProperties {
       contentType = Option(basicProps.getContentType),
       contentEncoding = Option(basicProps.getContentEncoding),
       priority = Option[Integer](basicProps.getPriority).map(Int.unbox),
-      deliveryMode = Option(basicProps.getDeliveryMode).map(DeliveryMode.from(_)),
+      deliveryMode = Option(basicProps.getDeliveryMode).map(DeliveryMode.unsafeFromInt(_)),
       correlationId = Option(basicProps.getCorrelationId),
       messageId = Option(basicProps.getMessageId),
       `type` = Option(basicProps.getType),

--- a/core/src/main/scala/dev/profunktor/fs2rabbit/model/values.scala
+++ b/core/src/main/scala/dev/profunktor/fs2rabbit/model/values.scala
@@ -95,9 +95,18 @@ object DeliveryMode {
   case object NonPersistent extends DeliveryMode(1)
   case object Persistent    extends DeliveryMode(2)
 
-  def from(value: Int): DeliveryMode = value match {
-    case 1 => NonPersistent
-    case 2 => Persistent
+  @deprecated("Use fromInt or unsafeFromInt", "5.3.0")
+  def from(value: Int): DeliveryMode =
+    unsafeFromInt(value)
+
+  def unsafeFromInt(value: Int): DeliveryMode =
+    fromInt(value)
+      .getOrElse(throw new IllegalArgumentException(s"Invalid delivery mode from Int: $value"))
+
+  def fromInt(value: Int): Option[DeliveryMode] = value match {
+    case 1 => Some(NonPersistent)
+    case 2 => Some(Persistent)
+    case _ => None
   }
 
   implicit val deliveryModeOrder: Order[DeliveryMode] = Order.by(_.value)

--- a/core/src/test/scala/dev/profunktor/fs2rabbit/testing/AmqpPropertiesArbs.scala
+++ b/core/src/test/scala/dev/profunktor/fs2rabbit/testing/AmqpPropertiesArbs.scala
@@ -166,7 +166,7 @@ object AmqpPropertiesArbs {
       contentType,
       contentEncoding,
       priority,
-      deliveryMode.map(DeliveryMode.from),
+      deliveryMode.map(DeliveryMode.unsafeFromInt),
       correlationId,
       messageId,
       messageType,

--- a/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/Fs2RabbitSpec.scala
+++ b/tests/src/test/scala/dev/profunktor/fs2rabbit/interpreter/Fs2RabbitSpec.scala
@@ -392,8 +392,8 @@ trait Fs2RabbitSpec { self: BaseSpec =>
         (q, x, _) = qxrk
         _        <- declareExchange(x, ExchangeType.Direct)
         _        <- declareQueue(DeclarationQueueConfig.default(q))
-        _        <- deleteQueue(DeletionQueueConfig.default(q))
-        _        <- deleteQueueNoWait(DeletionQueueConfig.default(q))
+        _        <- deleteQueue(DeletionQueueConfig.onlyIfUnusedAndEmpty(q))
+        _        <- deleteQueueNoWait(DeletionQueueConfig.onlyIfUnusedAndEmpty(q))
         consumer <- createAutoAckConsumer(q)
         _        <- consumer.attempt
                       .take(1)
@@ -415,7 +415,7 @@ trait Fs2RabbitSpec { self: BaseSpec =>
     createConnectionChannel.use { implicit channel =>
       mkRandomString.map(ExchangeName).flatMap { exchange =>
         declareExchange(exchange, ExchangeType.Direct) *>
-          deleteExchangeNoWait(DeletionExchangeConfig.default(exchange)).attempt.map(_ shouldBe a[Right[_, _]])
+          deleteExchangeNoWait(DeletionExchangeConfig.onlyIfUnused(exchange)).attempt.map(_ shouldBe a[Right[_, _]])
       }
     }
   }


### PR DESCRIPTION
Adds some methods, just aliases to copy, to setup settings fluently.

I have two doubts: 
- Is it better to use `with` or `as` ? 
- Is it better to accept booleans instead of `Durable/NonDurable`, etc.. ? Like `.withDurable(true)`