### PR TITLE
Remove Free2Move from adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Check the [official guide](https://fs2-rabbit.profunktor.dev/guide.html) for upd
 | [ITV](https://www.itv.com/)                                   | Internal microservices interaction.                             |
 | [Klarna](https://www.klarna.com/us/)                          | Microservice for Fintech services.                              |
 | [Philips Lighting](http://www.lighting.philips.com/main/home) | Internal microservices interaction.                             |
-| [Free2Move](https://free2move.com)                            | Microservice communication.                                     |
 | [Descartes Kontainers](https://kontainers.com)                | Microservice workflow management - Logistics applications.      |
 | [Codacy](https://www.codacy.com)                              | Internal microservices interaction.                             |
 | [Budgetbakers](https://budgetbakers.com)                      | Internal microservices communication - Fintech                  |


### PR DESCRIPTION
As noticed in #977, the adopters list has an outdated entry.